### PR TITLE
Set Default Cell Dimensions

### DIFF
--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -19,8 +19,12 @@ class EncodingTable(QTableWidget):
 
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.horizontalHeader().setDefaultSectionSize(60)
+        self.horizontalHeader().setMaximumSectionSize(100)
         self.verticalHeader().setStretchLastSection(True)
         self.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.verticalHeader().setDefaultSectionSize(30)
+        self.setStyleSheet("QTableWidget::item {border: 0px; padding: 5px;}")
 
         # Ensure at least 5 rows are visible at all times.
         self.minimum_visible_rows = 5

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -20,11 +20,13 @@ class EncodingTable(QTableWidget):
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.horizontalHeader().setDefaultSectionSize(60)
+        self.horizontalHeader().setMinimumSectionSize(60)
         self.horizontalHeader().setMaximumSectionSize(100)
         self.verticalHeader().setStretchLastSection(True)
         self.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
         self.verticalHeader().setDefaultSectionSize(30)
-        self.setStyleSheet("QTableWidget::item {border: 0px; padding: 5px;}")
+        self.verticalHeader().setMinimumSectionSize(30)
+        self.setStyleSheet("QTableWidget::item {border: 0px; padding: 10px;}")
 
         # Ensure at least 5 rows are visible at all times.
         self.minimum_visible_rows = 5


### PR DESCRIPTION
Added features to each cell to clean up the dimensions of table cells. Four lines of code were added to encoding_table.py: 22, 23, 26, 27

Line 22 sets the minimum width of a cell to 60
Line 23 sets the maximum width of a cell to 100
Line 26 sets the default height of a cell to 30
Line 27 sets padding conditions for the cell 

Testing Steps:
  1. Run main.py to start the application
  2. Visually inspect each cell in the encoding table to ensure the size is suitable 
  3. Type characters into a cell to check cell resizing and padding 

Type: New Feature