### PR TITLE
Changes table cell font, creates editable header labels, and allows column resizing

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -38,13 +38,25 @@ class Controller:
         self._window = window
 
         self._media_player = QMediaPlayer()
-        self._media_player.setVideoOutput(self._window.media_panel.video_widget)
-        self._media_player.setAudioOutput(self._window.media_panel.audio_widget)
+        self._media_player.setVideoOutput(
+            self._window.media_panel.video_widget)
+        self._media_player.setAudioOutput(
+            self._window.media_panel.audio_widget)
 
         self._window.connect_load_video_to_slot(self.open_file_dialog)
 
-        self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
-        self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
+        self._window.table_panel.add_col_button.clicked.connect(
+            self.add_col_to_encoding_table)
+        self._window.table_panel.add_row_button.clicked.connect(
+            self.add_row_to_encoding_table)
+
+        self._window.table_panel.change_font_dropDown.activated.connect(
+            self.change_font_of_encoding_table)
+
+        self._window.table_panel.table.horizontalHeader(
+        ).sectionDoubleClicked.connect(self.edit_header)
+        self._window.table_panel.table.horizontalHeader(
+        ).line.editingFinished.connect(self.done_editing)
 
     @Slot()
     def add_col_to_encoding_table(self):
@@ -55,6 +67,31 @@ class Controller:
     def add_row_to_encoding_table(self):
         """Command the table widget to add a row."""
         self._window.table_panel.table.add_row()
+
+    @Slot()
+    def change_font_of_encoding_table(self):
+        """
+        Get selected item from font dropdown.
+        Command table cells font to update to selected font size.
+        """
+        selected_font = int(
+            self._window.table_panel.change_font_dropDown.currentText())
+        self._window.table_panel.table.change_font(selected_font)
+
+    @Slot()
+    def edit_header(self, section):
+        """
+        Commands QLineEdit item to become editable.
+
+        Parameters:
+            section: keeps track of which column header is being edited.
+        """
+        self._window.table_panel.table.edit_header(section)
+
+    @Slot()
+    def done_editing(self):
+        """Commands the table widget to update header label to the text entered in the QLineEdit item"""
+        self._window.table_panel.table.done_editing()
 
     @Slot()
     def open_file_dialog(self):
@@ -93,7 +130,8 @@ class Controller:
         file_dialog.setMimeTypeFilters(mime_types)
 
         # Add an "all supported types" filter and make it the default.
-        glob_patterns_list = [item for sublist in glob_pattern_lists for item in sublist]
+        glob_patterns_list = [
+            item for sublist in glob_pattern_lists for item in sublist]
         glob_patterns_str = " ".join(glob_patterns_list)
         all_supported_types = f"All supported formats {glob_patterns_str}"
         name_filters = file_dialog.nameFilters()

--- a/View/coding_assistance_panel.py
+++ b/View/coding_assistance_panel.py
@@ -28,6 +28,7 @@ class CodingAssistancePanel(QWidget):
         empty_widget = QWidget()
 
         # Add the coding assistance related widgets to a vertical layout.
+
         vertical_layout.addWidget(self._title, stretch=1)
         vertical_layout.addWidget(empty_widget, stretch=6)
         vertical_layout.addWidget(self.button_panel, stretch=2)

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -1,5 +1,6 @@
-from PySide6 import QtWidgets
-from PySide6.QtWidgets import QTableWidget
+from PySide6 import QtWidgets, QtGui, QtCore
+from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QLineEdit
+from PySide6.QtGui import QFont
 
 
 class EncodingTable(QTableWidget):
@@ -18,19 +19,93 @@ class EncodingTable(QTableWidget):
         self.setColumnCount(4)
 
         self.horizontalHeader().setStretchLastSection(True)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
+        self.horizontalHeader().setDefaultSectionSize(60)
+        self.horizontalHeader().setMaximumSectionSize(400)
         self.verticalHeader().setStretchLastSection(True)
-        self.verticalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        self.verticalHeader().setSectionResizeMode(
+            QtWidgets.QHeaderView.ResizeToContents)
+        self.verticalHeader().setDefaultSectionSize(30)
+        self.setStyleSheet("QTableWidget::item {border: 0px; padding: 5px;}")
 
-        # Ensure at least 5 rows are visible at all times.
+        """Sets up QLineEdit item over headers"""
+        self.horizontalHeader().line = QLineEdit(
+            parent=self.horizontalHeader().viewport())
+        self.horizontalHeader().line.setAlignment(QtCore.Qt.AlignTop)
+        self.horizontalHeader().line.setHidden(True)
+        self.horizontalHeader().line.blockSignals(True)
+        self.horizontalHeader().sectionedit = 0
+
+        """Makes columns take up even space. It's not perfect but width/4 doesn't work either"""
+        for column in range(self.columnCount()):
+            self.setColumnWidth(column, self.width()/2)
+
+        """Ensure at least 5 rows are visible at all times."""
         self.minimum_visible_rows = 5
         total_border_height = 2
-        self.setMinimumHeight(self.rowHeight(0) * (self.minimum_visible_rows + total_border_height))
+        self.setMinimumHeight(self.rowHeight(
+            0) * (self.minimum_visible_rows + total_border_height))
+
+        """Sets the first column header to 'Time'"""
+        self.setHorizontalHeaderLabels(["Time"])
+
+        """Creates a QTableWidgetItem for all column headers whose type is None"""
+        for column in range(self.columnCount()):
+            if self.horizontalHeaderItem(column) is None:
+                self.setHorizontalHeaderItem(
+                    column, QTableWidgetItem(str(column)))
 
     def add_column(self):
         """Increases the column count of the table by 1."""
         self.setColumnCount(self.columnCount() + 1)
 
+        """Creates QTableWidgetItem for new column"""
+        column = self.columnCount() - 1
+        self.setHorizontalHeaderItem(column, QTableWidgetItem(str(column)))
+
     def add_row(self):
         """Increases the row count of the table by 1."""
         self.setRowCount(self.rowCount() + 1)
+
+    def change_font(self, font_choice):
+        """
+        Changes font size of cells.
+
+        Parameters:
+            font_choice: size of user selected font
+        """
+        font = self.font()
+        font.setPointSize(font_choice)
+        self.setFont(font)
+
+    def edit_header(self, section):
+        """
+        Enables the QLineEdit item over headers to be editable.
+
+        Parameters:
+            section: keeps track of which column header is being edited.
+        """
+        if section != 0:
+            edit_geo = self.horizontalHeader().line.geometry()
+            edit_geo.setWidth(self.horizontalHeader().sectionSize(section))
+            edit_geo.moveLeft(
+                self.horizontalHeader().sectionViewportPosition(section))
+            self.horizontalHeader().line.setGeometry(edit_geo)
+
+            self.horizontalHeader().line.setHidden(False)
+            self.horizontalHeader().line.blockSignals(False)
+            self.horizontalHeader().line.setFocus()
+            self.horizontalHeader().line.selectAll()
+            self.horizontalHeader().sectionedit = section
+
+    def done_editing(self):
+        """Updates header text when user is done editing QLineEdit item."""
+        self.horizontalHeader().line.blockSignals(True)
+        self.horizontalHeader().line.setHidden(True)
+        new_label = str(self.horizontalHeader().line.text())
+
+        if new_label != '':
+            self.setHorizontalHeaderItem(
+                self.horizontalHeader().sectionedit, QTableWidgetItem(new_label))
+            self.horizontalHeader().line.setText('')
+            self.horizontalHeader().setCurrentIndex(QtCore.QModelIndex())

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -74,7 +74,7 @@ class EncodingTable(QTableWidget):
         Changes font size of cells.
 
         Parameters:
-            font_choice: size of user selected font
+            font_choice: size of user selected font.
         """
         font = self.font()
         font.setPointSize(font_choice)

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -1,57 +1,6 @@
-from PySide6.QtWidgets import QTableWidget, QTableWidgetItem
 from PySide6.QtCore import QSettings
-from PySide6 import QtWidgets
-from PySide6.QtGui import QFont
 from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QLineEdit
-from PySide6 import QtWidgets, QtGui, QtCore
-<< << << < HEAD
-
-
-class EncodingTable(QTableWidget):
-    """
-    EncodingTable is a custom QTableWidget used to support encoding table
-    functionalities in the front-end.
-    """
-
-    def __init__(self):
-        """
-        Constructor - Sets the properties of a QTableWidget.
-        """
-        super().__init__()
-
-        self.setRowCount(10)
-        self.setColumnCount(4)
-
-        self.horizontalHeader().setStretchLastSection(True)
-        self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
-        self.horizontalHeader().setDefaultSectionSize(60)
-        self.horizontalHeader().setMaximumSectionSize(400)
-        self.verticalHeader().setStretchLastSection(True)
-        self.verticalHeader().setSectionResizeMode(
-            QtWidgets.QHeaderView.ResizeToContents)
-        self.verticalHeader().setDefaultSectionSize(30)
-        self.setStyleSheet("QTableWidget::item {border: 0px; padding: 5px;}")
-
-        """Ensure at least 5 rows are visible at all times."""
-        self.minimum_visible_rows = 5
-        total_border_height = 2
-        self.setMinimumHeight(self.rowHeight(
-            0) * (self.minimum_visible_rows + total_border_height))
-
-    def add_column(self):
-        """Increases the column count of the table by 1."""
-        self.setColumnCount(self.columnCount() + 1)
-
-        """Creates QTableWidgetItem for new column"""
-        column = self.columnCount() - 1
-        self.setHorizontalHeaderItem(column, QTableWidgetItem(str(column)))
-
-    def add_row(self):
-        """Increases the row count of the table by 1."""
-        self.setRowCount(self.rowCount() + 1)
-
-
-== == == =
+from PySide6 import QtWidgets, QtCore
 
 
 class EncodingTable(QTableWidget):
@@ -248,6 +197,3 @@ class EncodingTable(QTableWidget):
         settings.endGroup()  # table-data
         settings.endGroup()  # encoding-table
         settings.endGroup()  # session-id
-
-
->>>>>> > main

--- a/View/media_control_panel.py
+++ b/View/media_control_panel.py
@@ -29,7 +29,7 @@ class MediaControlPanel(QWidget):
         horizontal_layout.addWidget(self.play_pause_button)
 
         # Add vertical box layout to add all widgets.
-        vertical_layout = VBoxLayout()
+        vertical_layout = QVBoxLayout()
         vertical_layout.addLayout(horizontal_layout)
         
         # Create empty widgets to fill negative space (remove later).

--- a/View/table_panel.py
+++ b/View/table_panel.py
@@ -1,5 +1,5 @@
-from PySide6.QtWidgets import QWidget, QPushButton, QGridLayout, QSizePolicy
 
+from PySide6.QtWidgets import QWidget, QPushButton, QGridLayout, QSizePolicy, QComboBox, QLabel
 from View.encoding_table import EncodingTable
 
 
@@ -14,16 +14,27 @@ class TablePanel(QWidget):
         super().__init__()
 
         self.table = EncodingTable()
-        self.add_col_button = QPushButton("Add Column")
-        self.add_row_button = QPushButton("Add Row")
+
+        self.add_col_button = QPushButton("Add column")
+        self.add_row_button = QPushButton("Add row")
 
         # Configure the add column button to expand vertically.
         self.add_col_button.setSizePolicy(
             QSizePolicy.Preferred,
             QSizePolicy.Expanding)
 
+        """Creates font changing label and dropdown"""
+        font_options = ["8", "9", "10", "11", "12", "14", "16",
+                        "18", "20", "22", "24", "26", "28", "36", "48", "72"]
+        self.change_font_label = QLabel("Change font: ")
+        self.change_font_dropDown = QComboBox()
+        self.change_font_dropDown.addItems(font_options)
+
         grid_layout = QGridLayout()
         grid_layout.addWidget(self.table, 0, 0)
-        grid_layout.addWidget(self.add_col_button, 0, 1)
+        grid_layout.addWidget(self.add_col_button, 1, 1)
         grid_layout.addWidget(self.add_row_button, 1, 0)
+        grid_layout.addWidget(self.change_font_label, 0, 1)
+        grid_layout.addWidget(self.change_font_dropDown, 0, 2)
+
         self.setLayout(grid_layout)


### PR DESCRIPTION
Added a combobox to select font size for table cells. Enabled click and drag column resizing by setting the SectionResizeMode to Interactive. Finally, added QLineEdit items over table headers to enable double click editing of table headers.

Testing Steps-
  1. Enter text in any cell and change the font size in the drop down.
  2. Enter text in another cell and ensure currently selected font size is maintained.
  3. Change font size again and ensure both cells update accordingly.
  4. Click and drag columns to ensure resizing working.
  5. Add 2 columns and try to resize them
  6. Double click the "Time" header and make sure it is not editable
  7. Double click another header and change the label. Press enter.
  8. Add a column and change the new columns header label.
  9. Double click a header, don't enter text and press enter. Ensure that original header stays.

Type - New Feature