### PR TITLE
Fixes the persistence of table headers

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -56,10 +56,8 @@ class Controller:
         self._window.table_panel.table.horizontalHeader(
         ).line.editingFinished.connect(self.done_editing)
 
-        self._window.table_panel.add_col_button.clicked.connect(
-            self.add_col_to_encoding_table)
-        self._window.table_panel.add_row_button.clicked.connect(
-            self.add_row_to_encoding_table)
+        self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
+        self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
 
         self._window.media_panel.media_control_panel.play_pause_button.clicked.connect(
             self.play_video)
@@ -79,9 +77,6 @@ class Controller:
         self.curr_time_minutes = 0
         self.curr_time_hours = 0
         self._media_player.positionChanged.connect(self.get_video_time_total)
-
-        self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
-        self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
 
     @Slot()
     def add_col_to_encoding_table(self):

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -26,9 +26,9 @@ class EncodingTable(QTableWidget):
             QtWidgets.QHeaderView.ResizeToContents)
         self.verticalHeader().setDefaultSectionSize(70)
 
-        # Map the initial header values to [0, columnCount).
-        for colIx in range(self.columnCount()):
-            self.setHorizontalHeaderItem(colIx, QTableWidgetItem(str(colIx)))
+        # Map the initial header values to [1, columnCount].
+        for col_ix in range(self.columnCount()):
+            self.setHorizontalHeaderItem(col_ix, QTableWidgetItem(str(col_ix + 1)))
 
         # Ensure at least 5 rows are visible at all times.
         self.minimum_visible_rows = 5
@@ -121,12 +121,17 @@ class EncodingTable(QTableWidget):
         settings.beginGroup(session_id)
         settings.beginGroup("encoding-table")
 
-        # Update the column count of the table.
+        # Update the row and column counts of the table.
+        self.setRowCount(int(settings.value("rows")))
         self.setColumnCount(int(settings.value("columns")))
 
         # Update the headers of the table.
-        for colIx in range(self.columnCount()):
-            self.setHorizontalHeaderItem(colIx, QTableWidgetItem(str(colIx)))
+        settings.beginReadArray("headers")
+        for col_ix in range(self.columnCount()):
+            settings.setArrayIndex(col_ix)
+            header = settings.value("header")
+            self.setHorizontalHeaderItem(col_ix, QTableWidgetItem(header))
+        settings.endArray()
 
         # Update the table data of the table.
         settings.beginGroup("table-data")
@@ -170,16 +175,19 @@ class EncodingTable(QTableWidget):
         settings.beginGroup(session_id)
         settings.beginGroup("encoding-table")
 
-        # Save the column count.
+        # Save the row and column count.
+        settings.setValue("rows", self.rowCount())
         settings.setValue("columns", self.columnCount())
 
         # Save the table headers.
         settings.beginWriteArray("headers", self.columnCount())
-        for colIx in range(self.columnCount()):
-            settings.setArrayIndex(colIx)
-            if self.horizontalHeaderItem(colIx).text() is not None:
+        for col_ix in range(self.columnCount()):
+            settings.setArrayIndex(col_ix)
+            if self.horizontalHeaderItem(col_ix) is not None:
                 settings.setValue(
-                    "header", self.horizontalHeaderItem(colIx).text())
+                    "header", self.horizontalHeaderItem(col_ix).text())
+            else:
+                settings.setValue("header", str(col_ix + 1))
         settings.endArray()
 
         # Save the table data


### PR DESCRIPTION
This patch fixes table persistence, such that headers are now correctly preserved between sessions.

This change also fixes the "add row" and "add column" bug, where the buttons would add two rows or two columns, per click, respectively. The signal was connected to twice, most likely due to a previous merge.

Testing Steps
  1. Run main.py to start the application.
  2. Create a new session
  3. Change the header of column 2 to "test"
  4. Click the "add column" button
  5. Click the "add row" button
  6. Restart the application and load the most recent session
  7. Verify that the second header reads "test"
  8. Verify that there are 5 rows and 11 columns, labeled correctly
  9. Change the header of column 3 to "test"
  10. Restart the application and load the most recent session
  11. Verify that the third header reads "test"

Type: Fix