### PR TITLE
Dev add buttons to button panel

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -1,10 +1,11 @@
 import sys
 
-from PySide6.QtCore import Slot, QMimeDatabase
+from PySide6.QtCore import Slot, QMimeDatabase, QObject
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
-from PySide6.QtWidgets import QFileDialog, QDialog, QStyle
+from PySide6.QtWidgets import QFileDialog, QDialog, QStyle, QPushButton
 
 from View.user_settings_dialog import UserSettingsDialog
+from View.coding_assistance_button_dialog import CodingAssistanceButtonDialog
 
 
 def get_supported_mime_types():
@@ -82,6 +83,9 @@ class Controller:
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
         self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
+
+        self._window.coding_assistance_panel.button_panel.connect_add_button_to_slot(self.open_coding_assistance_dialog)
+        #self._window.coding_assistance_panel.button_panel.connect_new_button_to_slot(self.coding_assistance_button_operation)
 
     @Slot()
     def add_col_to_encoding_table(self):
@@ -327,3 +331,36 @@ class Controller:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPause))
         else:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPlay))
+
+    @Slot()
+    def open_coding_assistance_dialog(self):
+        """Open a dialog to create a new Coding Assistance Button"""
+        self.coding_assistance_button_dialog = CodingAssistanceButtonDialog()
+        self.coding_assistance_button_dialog.connect_create_button_to_slot(self.create_coding_assistance_button)
+        self.coding_assistance_button_dialog.exec()
+
+    @Slot()
+    def create_coding_assistance_button(self):
+        """Add a button to the Coding Assistance Panel"""
+        button_title = self.coding_assistance_button_dialog.apply_text_field.text()
+        button_hotkey = self.coding_assistance_button_dialog.hotkey_field.text()
+
+        if len(self.coding_assistance_button_dialog.hotkeys) == 0:
+            self.coding_assistance_button_dialog.hotkeys.append(button_hotkey)
+            self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(button_title,
+                                                                                              button_hotkey)
+        else:
+            for hotkey in self.coding_assistance_button_dialog.hotkeys:
+                if hotkey == button_hotkey:
+                    self.coding_assistance_button_dialog.error_label.setText("This hotkey is already being used!")
+                    break
+                else:
+                    self.coding_assistance_button_dialog.hotkeys.append(button_hotkey)
+                    self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(button_title,
+                                                                                                      button_hotkey)
+
+
+    @Slot()
+    def coding_assistance_button_operation(self):
+        """Set the data a Coding Assistance Button will input into the table"""
+

--- a/View/button_panel.py
+++ b/View/button_panel.py
@@ -1,4 +1,6 @@
-from PySide6.QtWidgets import QWidget, QPushButton, QHBoxLayout, QSizePolicy, QGridLayout
+from PySide6.QtCore import QObject
+from PySide6.QtGui import QKeySequence
+from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QSizePolicy, QGridLayout
 
 
 class ButtonPanel(QWidget):
@@ -7,25 +9,21 @@ class ButtonPanel(QWidget):
     def __init__(self):
         """
         Constructor - Creates the Coding Assistance buttons and adds them
-        into a QHBoxLayout.
+        into a QVBoxLayout.
         """
         super().__init__()
 
         button_container = QWidget()
-        horizontal_layout = QHBoxLayout()
+        self.vertical_layout = QVBoxLayout()
 
-        # Create four placeholder buttons.
-        buttons = [QPushButton("Button 1"), QPushButton("Button 2"),
-                   QPushButton("Button 3"), QPushButton("Button 4")]
+        self.add_button = QPushButton("+")
 
-        # Add each button to the horizontal layout and set their sizing policies.
-        for button in buttons:
-            horizontal_layout.addWidget(button, stretch=1)
-            button.setSizePolicy(
-                QSizePolicy.Preferred,
-                QSizePolicy.Expanding)
+        self.vertical_layout.addWidget(self.add_button)
+        self.add_button.setSizePolicy(
+            QSizePolicy.Preferred,
+            QSizePolicy.Expanding)
 
-        button_container.setLayout(horizontal_layout)
+        button_container.setLayout(self.vertical_layout)
 
         # Add css styling to the container to give it a background color.
         button_container.setProperty("class", "button-container")
@@ -40,3 +38,16 @@ class ButtonPanel(QWidget):
         # Add the button container to the button panel.
         self.setLayout(QGridLayout())
         self.layout().addWidget(button_container)
+
+    def connect_add_button_to_slot(self, slot):
+        """
+        Connects an add_button event to a slot function in the controller.
+        """
+        self.add_button.clicked.connect(slot)
+
+    def create_coding_assistance_button(self, button_title, button_hotkey):
+        """Adds a new_button to the Coding Assistance Panel"""
+        self.new_button = QPushButton(button_title)
+        self.new_button.setShortcut(button_hotkey)
+
+        self.vertical_layout.insertWidget(0, self.new_button)

--- a/View/coding_assistance_button_dialog.py
+++ b/View/coding_assistance_button_dialog.py
@@ -1,0 +1,46 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton, QLineEdit
+
+
+class CodingAssistanceButtonDialog(QDialog):
+
+    def __init__(self):
+        """
+        Constructor: Initializes the layout of the Coding Assistance Button dialog
+        """
+        super().__init__()
+
+        self.hotkeys = []
+
+        # Creates a vertical layout for the dialog box.
+        dialog_layout = QVBoxLayout()
+
+        apply_text_hbox = QHBoxLayout()
+        apply_text_label = QLabel("Button Label: ")
+        self.apply_text_field = QLineEdit()
+        apply_text_hbox.addWidget(apply_text_label)
+        apply_text_hbox.addWidget(self.apply_text_field)
+
+        hotkey_hbox = QHBoxLayout()
+        hotkey_label = QLabel("Assign a hotkey for this button: ")
+        self.hotkey_field = QLineEdit()
+        hotkey_hbox.addWidget(hotkey_label)
+        hotkey_hbox.addWidget(self.hotkey_field)
+
+        self.error_label = QLabel()
+
+        self.create_button = QPushButton("Create")
+
+        dialog_layout.addLayout(apply_text_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addLayout(hotkey_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addWidget(self.error_label)
+        dialog_layout.addWidget(self.create_button)
+
+        self.setLayout(dialog_layout)
+
+    def connect_create_button_to_slot(self, slot):
+        """
+        Connect a create_button event to a slot function in the controller.
+        """
+        self.create_button.clicked.connect(slot)


### PR DESCRIPTION
Adds a change to the Coding Assistance Panel where the "+" button now opens a dialog that allows the user add a new button to the Coding Assistance Panel. The dialog allows the user to label the button and assign a hotkey to the button. Hotkeys cannot be reused.

Testing Steps
  1. Open the Application and start a new session
  2. Click the + button under "Coding Assistance Buttons"
  3. Give a title and a hotkey "a" to the button and press the "Create" button
  4. Verify the button has been added and has the correct label
  5. Press the "Create" button again without changing the parameters and verify the text "This hotkey is already being used!" shows in the dialog
  6. Change the hotkey to "s" and click the "Create" button
  7. Verify a new button is created.

Type: New Feature