### PR TITLE
Dev save tabledata to csv

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -4,6 +4,9 @@ from PySide6.QtCore import Slot, QMimeDatabase, QByteArray
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
 from PySide6.QtWidgets import QFileDialog, QDialog, QMessageBox
 
+import io
+import csv
+
 
 def get_supported_mime_types():
     """
@@ -118,22 +121,23 @@ class Controller:
         # Opens the file browser on the main window.
         file_dialog = QFileDialog(self._window)
 
+        output = io.StringIO()
+        csv_writer = csv.writer(output, delimiter=",", quoting=csv.QUOTE_NONNUMERIC)
+
         # Traverse over the table data and format data in CSV style.
         num_rows = self._window.table_panel.table.rowCount()
         num_columns = self._window.table_panel.table.columnCount()
-        table_data = ""
         for y in range(num_rows):
+            table_row = []
             for x in range(num_columns):
                 item = self._window.table_panel.table.item(y, x)
                 if item is not None:
-                    single_entity_of_table = "\"" + item.text() + "\","
-                    table_data += single_entity_of_table
+                    single_entity_of_table = item.text()
+                    table_row.append(single_entity_of_table)
                 else:
-                    table_data += ","
-            # Remove the excess comma from string at end.
-            table_data = table_data[:-1]
-            table_data += "\n"
+                    table_row.append("")
+            csv_writer.writerow(table_row)
 
         # Convert to a byte array and open file browser to save.
-        table_data_as_byte_array = QByteArray(table_data)
+        table_data_as_byte_array = QByteArray(output.getvalue())
         file_dialog.saveFileContent(table_data_as_byte_array, "your_table_data.csv")

--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -128,9 +128,11 @@ class Controller:
                 if item is not None:
                     single_entity_of_table = "\"" + item.text() + "\","
                     table_data += single_entity_of_table
-
-        # Remove the excess comma from string at end.
-        table_data = table_data[:-1]
+                else:
+                    table_data += ","
+            # Remove the excess comma from string at end.
+            table_data = table_data[:-1]
+            table_data += "\n"
 
         # Convert to a byte array and open file browser to save.
         table_data_as_byte_array = QByteArray(table_data)

--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide6.QtCore import Slot, QMimeDatabase
+from PySide6.QtCore import Slot, QMimeDatabase, QByteArray
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
 from PySide6.QtWidgets import QFileDialog, QDialog, QMessageBox
 
@@ -115,7 +115,23 @@ class Controller:
         save_to_file() - Slot function that will act as a handler whenever the
         Save table data button is clicked.
         """
-        self._window.save_to_file_popup.setText("Do you want to save table data?")
-        self._window.save_to_file_popup.addButton(QMessageBox.Cancel)
-        self._window.save_to_file_popup.addButton(QMessageBox.Save)
-        self._window.save_to_file_popup.show()
+        # Opens the file browser on the main window.
+        file_dialog = QFileDialog(self._window)
+
+        # Traverse over the table data and format data in CSV style.
+        num_rows = self._window.table_panel.table.rowCount()
+        num_columns = self._window.table_panel.table.columnCount()
+        table_data = ""
+        for y in range(num_rows):
+            for x in range(num_columns):
+                item = self._window.table_panel.table.item(y, x)
+                if item is not None:
+                    single_entity_of_table = "\"" + item.text() + "\","
+                    table_data += single_entity_of_table
+
+        # Remove the excess comma from string at end.
+        table_data = table_data[:-1]
+
+        # Convert to a byte array and open file browser to save.
+        table_data_as_byte_array = QByteArray(table_data)
+        file_dialog.saveFileContent(table_data_as_byte_array, "your_table_data.csv")

--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -2,7 +2,7 @@ import sys
 
 from PySide6.QtCore import Slot, QMimeDatabase
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
-from PySide6.QtWidgets import QFileDialog, QDialog
+from PySide6.QtWidgets import QFileDialog, QDialog, QMessageBox
 
 
 def get_supported_mime_types():
@@ -45,6 +45,8 @@ class Controller:
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
         self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
+
+        self._window.connect_export_file_to_slot(self.save_to_file)
 
     @Slot()
     def add_col_to_encoding_table(self):
@@ -106,3 +108,14 @@ class Controller:
             url = file_dialog.selectedUrls()[0]
             self._media_player.setSource(url)
             self._media_player.play()
+
+    @Slot()
+    def save_to_file(self):
+        """
+        save_to_file() - Slot function that will act as a handler whenever the
+        Save table data button is clicked.
+        """
+        self._window.save_to_file_popup.setText("Do you want to save table data?")
+        self._window.save_to_file_popup.addButton(QMessageBox.Cancel)
+        self._window.save_to_file_popup.addButton(QMessageBox.Save)
+        self._window.save_to_file_popup.show()

--- a/View/main_window.py
+++ b/View/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMainWindow, QStyle, QHBoxLayout, QWidget, QVBoxLayout
+from PySide6.QtWidgets import QMainWindow, QStyle, QHBoxLayout, QWidget, QVBoxLayout, QMessageBox
 
 from View.coding_assistance_panel import CodingAssistancePanel
 from View.media_panel import MediaPanel
@@ -21,6 +21,9 @@ class MainWindow(QMainWindow):
         self.setWindowState(Qt.WindowMaximized)
 
         self.create_menu_bar()
+        popup = QMessageBox()
+        self.save_to_file_popup = popup
+
 
         self.table_panel = TablePanel()
         self.media_panel = MediaPanel()
@@ -38,10 +41,20 @@ class MainWindow(QMainWindow):
         """
         self._open_action.triggered.connect(slot)
 
+    def connect_export_file_to_slot(self, slot):
+        """
+        In this case this function checks whether the Save table data button is pressed
+        then calls the slot specific slot function in the controller.
+
+        Parameters:
+            slot: The handler function that is called when the signal is clicked.
+        """
+        self._save_action.triggered.connect(slot)
+
     def create_menu_bar(self):
         """
         Creates the main menu-bar for the application window and populates it with a
-        File sub-menu.
+        File sub-menu and Export sub-menu.
         """
         file_menu = self.menuBar().addMenu("File")
         # Accesses image from the resource qrc file.
@@ -50,6 +63,14 @@ class MainWindow(QMainWindow):
         # Adds a load video button with an action.
         self._open_action = QAction(file_dialog_icon, "Load video file", self)
         file_menu.addAction(self._open_action)
+
+        # This adds a new sub-menu for exporting a file.
+        export_menu = self.menuBar().addMenu("Export")
+        export_dialog_icon = self.style().standardIcon(QStyle.SP_DialogSaveButton)
+
+        # Adds a Save table data button with an action.
+        self._save_action = QAction(export_dialog_icon, "Save table data", self)
+        export_menu.addAction(self._save_action)
 
     def set_layout(self):
         """

--- a/View/main_window.py
+++ b/View/main_window.py
@@ -21,9 +21,6 @@ class MainWindow(QMainWindow):
         self.setWindowState(Qt.WindowMaximized)
 
         self.create_menu_bar()
-        popup = QMessageBox()
-        self.save_to_file_popup = popup
-
 
         self.table_panel = TablePanel()
         self.media_panel = MediaPanel()

--- a/View/main_window.py
+++ b/View/main_window.py
@@ -86,6 +86,13 @@ class MainWindow(QMainWindow):
         self._open_settings_dialog_action = QAction(settings_dialog_icon, "Settings", self)
         file_menu.addAction(self._open_file_dialog_action)
         settings_menu.addAction(self._open_settings_dialog_action)
+        # This adds a new sub-menu for exporting a file.
+        export_menu = self.menuBar().addMenu("Export")
+        export_dialog_icon = self.style().standardIcon(QStyle.SP_DialogSaveButton)
+
+        # Adds a Save table data button with an action.
+        self._save_action = QAction(export_dialog_icon, "Save table data", self)
+        export_menu.addAction(self._save_action)
 
     def read_settings(self):
         """
@@ -94,14 +101,6 @@ class MainWindow(QMainWindow):
         """
         self.table_panel.read_settings(self.session_id)
         self.table_panel.table.read_settings(self.session_id)
-
-        # This adds a new sub-menu for exporting a file.
-        export_menu = self.menuBar().addMenu("Export")
-        export_dialog_icon = self.style().standardIcon(QStyle.SP_DialogSaveButton)
-
-        # Adds a Save table data button with an action.
-        self._save_action = QAction(export_dialog_icon, "Save table data", self)
-        export_menu.addAction(self._save_action)
 
     def set_layout(self):
         """


### PR DESCRIPTION
Export table data to csv file

In this patch an export button was added so the user can 
export the table data to a csv formatted file. The reason behind
this is so the user can ultimately take the data they taken from
the video and export it as a csv file so they can use it in other
applications.

1. Run the program
2. Make sure the export button shows up top
3. Enter in test table data in any of the rows
4. Click export and save to csv
5. Save the file anywhere on your computer
6. Make sure the files formatting looks correct

Type: New Feature