### PR TITLE
Dev adjust start end of scrub bar

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -83,6 +83,9 @@ class Controller:
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
         self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
 
+        self._window.media_panel.media_control_panel.input_start_time.editingFinished.connect(self.change_scrub_start)
+        self._window.media_panel.media_control_panel.input_end_time.editingFinished.connect(self.change_scrub_end)
+
     @Slot()
     def add_col_to_encoding_table(self):
         """ Command the table widget to add a column. """
@@ -327,3 +330,29 @@ class Controller:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPause))
         else:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPlay))
+
+    @Slot()
+    def change_scrub_start(self):
+        """
+        Changes the start position of the scrubbing bar.
+        """
+        str_start_time = self._window.media_panel.media_control_panel.input_start_time.text()
+        int_start_time = int(str_start_time)
+        #duration = self._media_player.duration()
+        #temp = self._window.media_panel.progress_bar_slider.minimum
+        #print(temp)
+        self._window.media_panel.progress_bar_slider.setMinimum(int_start_time)
+        #temp = self._window.media_panel.progress_bar_slider.minimum
+        #print(temp)
+
+    @Slot()
+    def change_scrub_end(self):
+        """
+        Changes the end position of the scrubbing bar.
+        """
+        str_end_time = self._window.media_panel.media_control_panel.input_end_time.text()
+        int_end_time = int(str_end_time)
+        #position = self._media_player.position()
+        #print(self._window.media_panel.progress_bar_slider.maximum)
+        self._window.media_panel.progress_bar_slider.setMaximum(int_end_time)
+        #print(self._window.media_panel.progress_bar_slider.maximum)

--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -337,13 +337,8 @@ class Controller:
         Changes the start position of the scrubbing bar.
         """
         str_start_time = self._window.media_panel.media_control_panel.input_start_time.text()
-        int_start_time = int(str_start_time)
-        #duration = self._media_player.duration()
-        #temp = self._window.media_panel.progress_bar_slider.minimum
-        #print(temp)
+        int_start_time = int(str_start_time) * 1000
         self._window.media_panel.progress_bar_slider.setMinimum(int_start_time)
-        #temp = self._window.media_panel.progress_bar_slider.minimum
-        #print(temp)
 
     @Slot()
     def change_scrub_end(self):
@@ -351,8 +346,5 @@ class Controller:
         Changes the end position of the scrubbing bar.
         """
         str_end_time = self._window.media_panel.media_control_panel.input_end_time.text()
-        int_end_time = int(str_end_time)
-        #position = self._media_player.position()
-        #print(self._window.media_panel.progress_bar_slider.maximum)
+        int_end_time = int(str_end_time) * 1000
         self._window.media_panel.progress_bar_slider.setMaximum(int_end_time)
-        #print(self._window.media_panel.progress_bar_slider.maximum)

--- a/View/media_control_panel.py
+++ b/View/media_control_panel.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QWidget, QPushButton, QStyle, \
-        QVBoxLayout, QHBoxLayout, QLabel
+    QVBoxLayout, QHBoxLayout, QLabel, QLineEdit
 
 from View.playback_speed_combo_box import PlaybackSpeedComboBox
 
@@ -28,9 +28,16 @@ class MediaControlPanel(QWidget):
         self.time_stamp = QLabel()
         self.time_stamp.setText("")
 
+        # Create start and end time text boxes.
+        self.input_start_time = QLineEdit()
+        self.input_start_time.setPlaceholderText("Enter Start Time")
+        self.input_end_time = QLineEdit()
+        self.input_end_time.setPlaceholderText("Enter End Time")
+
         # Create empty widgets to fill negative space (remove later).
         empty_widget1 = QWidget()
         empty_widget2 = QWidget()
+        empty_widget3 = QWidget()
 
         # Adds the widgets to the layout.
         horizontal_layout.addWidget(self.playback_speed_combo_box, stretch=3)
@@ -38,5 +45,8 @@ class MediaControlPanel(QWidget):
         horizontal_layout.addWidget(self.play_pause_button, stretch=1)
         horizontal_layout.addWidget(empty_widget2, stretch=4)
         horizontal_layout.addWidget(self.time_stamp, stretch=2)
+        horizontal_layout.addWidget(empty_widget3, stretch=4)
+        horizontal_layout.addWidget(self.input_start_time, stretch=4)
+        horizontal_layout.addWidget(self.input_end_time, stretch=4)
 
         self.setLayout(horizontal_layout)


### PR DESCRIPTION
Adjust the minimum and maximum range of the scrubbing bar

In this patch we started the initial phase of the scalable scrubbing bar.
The first implementation allowed for 2 text boxes that the user could type
in to adjust the start and end time. This should change the start and end of
the displayed scrubbing bar. The reason behind this patch is to eventually 
build up to the final implementation of the scrubbing bar.

1. Run the program
2. Load a video
3. Enter a start time
4. Move scrubbing bar back to start to see if it updated
5. Enter an end time
6. Move scrubbing bar to end to see if updated (video should end,
only scrubbing bar adjusted)
7. Test again with both start and end added

Type: New Feature