### PR TITLE
Adds forward/backward + setting + timestamp

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QFileDialog, QDialog, QStyle, QInputDialog, QLineE
 from View.user_settings_dialog import UserSettingsDialog
 
 
+
 def get_supported_mime_types():
     """
     get_supported_mime_types() - This returns a list of supported
@@ -64,6 +65,14 @@ class Controller:
 
         self._window.media_panel.progress_bar_slider.sliderMoved.connect(
             self.set_position)
+
+        self._window.media_panel.media_control_panel.forward_button.clicked.connect(
+            self.forward)
+
+        self._window.media_panel.media_control_panel.backward_button.clicked.connect(
+            self.backward)
+
+        self._window.media_panel.media_control_panel.go_to_timestamp_button.clicked.connect(self.go_to_timestamp)
 
         self._media_player.positionChanged.connect(self.position_changed)
         self._media_player.durationChanged.connect(self.duration_changed)
@@ -349,3 +358,20 @@ class Controller:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPause))
         else:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPlay))
+
+    @Slot()
+    def forward(self):
+        #current_position = self._media_player.position()
+        self._media_player.setPosition(self._media_player.position() + 2000)  # forward 2
+
+
+    @Slot()
+    def backward(self):
+        #current_position = self._media_player.position()
+        self._media_player.setPosition(self._media_player.position() - 2000)  # backward 2
+
+    @Slot()
+    def go_to_timestamp(self):
+        timestamp = int(self._window.media_panel.media_control_panel.timestamp_input.text())
+        self._media_player.setPosition(timestamp * 1000)
+

--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import QFileDialog, QDialog, QStyle, QInputDialog, QLineE
 from View.user_settings_dialog import UserSettingsDialog
 
 
-
 def get_supported_mime_types():
     """
     get_supported_mime_types() - This returns a list of supported
@@ -67,10 +66,10 @@ class Controller:
             self.set_position)
 
         self._window.media_panel.media_control_panel.forward_button.clicked.connect(
-            self.forward)
+            self.skip_video_forward)
 
         self._window.media_panel.media_control_panel.backward_button.clicked.connect(
-            self.backward)
+            self.skip_video_backward)
 
         self._window.media_panel.media_control_panel.go_to_timestamp_button.clicked.connect(self.go_to_timestamp)
 
@@ -260,6 +259,7 @@ class Controller:
         self.user_settings.connect_cell_size_to_slot(self.set_cell_size)
         self.user_settings.connect_maximum_size_to_slot(self.set_maximum_width)
         self.user_settings.connect_padding_to_slot(self.set_padding)
+        self.user_settings.connect_seconds_skip_to_slot(self.set_second_jumps_forward_backward_scrubbing)
         self.user_settings.exec()
 
     @Slot()
@@ -351,6 +351,40 @@ class Controller:
         self._media_player.setPosition(position)
 
     @Slot()
+    def set_second_jumps_forward_backward_scrubbing(self):
+        """
+        Sets the number of seconds that the forward and backward buttons skip
+        by based on the user-input skip amount in the user settings box.
+        """
+        try:
+            skip_amount_seconds = int(self.user_settings.seconds_skip_text_box.text())
+            self._window.media_panel.media_control_panel.time_step_seconds = skip_amount_seconds
+        except ValueError:
+            print("Invalid user settings: seconds to skip")
+
+    @Slot()
+    def skip_video_backward(self):
+        """
+        Slot function for the backwards button in the media control panel. This
+        slot function skips the state of the media player backwards by the
+        number of seconds set by the time_step field in the media control panel.
+        """
+        current_position = self._media_player.position()
+        time_jump_seconds = self._window.media_panel.media_control_panel.time_step_seconds * 1000
+        self._media_player.setPosition(current_position - time_jump_seconds)
+
+    @Slot()
+    def skip_video_forward(self):
+        """
+        Slot function for the forward button in the media control panel. This
+        slot function skips the state of the media player forwards by the
+        number of seconds set by the time_step field in the media control panel.
+        """
+        current_position = self._media_player.position()
+        time_jump_seconds = self._window.media_panel.media_control_panel.time_step_seconds * 1000
+        self._media_player.setPosition(current_position + time_jump_seconds)
+
+    @Slot()
     def toggle_play_pause_icon(self):
         """ Toggles the icon of the play/pause button. """
         button = self._window.media_panel.media_control_panel.play_pause_button
@@ -358,17 +392,6 @@ class Controller:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPause))
         else:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPlay))
-
-    @Slot()
-    def forward(self):
-        #current_position = self._media_player.position()
-        self._media_player.setPosition(self._media_player.position() + 2000)  # forward 2
-
-
-    @Slot()
-    def backward(self):
-        #current_position = self._media_player.position()
-        self._media_player.setPosition(self._media_player.position() - 2000)  # backward 2
 
     @Slot()
     def go_to_timestamp(self):

--- a/View/media_control_panel.py
+++ b/View/media_control_panel.py
@@ -29,6 +29,7 @@ class MediaControlPanel(QWidget):
         self.time_stamp.setText("")
 
         # Create the forward backward button
+        self.time_step_seconds = 2
         self.forward_button = QPushButton("Forward")
         self.backward_button = QPushButton("Backward")
 

--- a/View/media_control_panel.py
+++ b/View/media_control_panel.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QWidget, QPushButton, QStyle, \
-        QVBoxLayout, QHBoxLayout, QLabel
+    QVBoxLayout, QHBoxLayout, QLabel, QLineEdit
 
 from View.playback_speed_combo_box import PlaybackSpeedComboBox
 
@@ -28,15 +28,27 @@ class MediaControlPanel(QWidget):
         self.time_stamp = QLabel()
         self.time_stamp.setText("")
 
+        # Create the forward backward button
+        self.forward_button = QPushButton("Forward")
+        self.backward_button = QPushButton("Backward")
+
         # Create empty widgets to fill negative space (remove later).
         empty_widget1 = QWidget()
         empty_widget2 = QWidget()
 
+        # Create widgets for the user input
+        self.timestamp_input = QLineEdit()
+        self.go_to_timestamp_button = QPushButton("Go to timestamp")
+
         # Adds the widgets to the layout.
         horizontal_layout.addWidget(self.playback_speed_combo_box, stretch=3)
         horizontal_layout.addWidget(empty_widget1, stretch=3)
+        horizontal_layout.addWidget(self.backward_button, stretch=2)
         horizontal_layout.addWidget(self.play_pause_button, stretch=1)
+        horizontal_layout.addWidget(self.forward_button, stretch=2)
         horizontal_layout.addWidget(empty_widget2, stretch=4)
         horizontal_layout.addWidget(self.time_stamp, stretch=2)
+        horizontal_layout.addWidget(self.timestamp_input)
+        horizontal_layout.addWidget(self.go_to_timestamp_button)
 
         self.setLayout(horizontal_layout)

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -17,6 +17,9 @@ class UserSettingsDialog(QDialog):
         maximum_width_hbox = QHBoxLayout()
         padding_hbox = QHBoxLayout()
 
+        # Create a new horizontal layout for the "Number of frames to skip" setting
+        frames_skip_hbox = QHBoxLayout()
+
         # Initializes the widgets of the dialog.
         encoding_table_label = QLabel("Encoding Table Settings:")
         minimum_size_label = QLabel("Set minimum cell width and height")
@@ -29,6 +32,11 @@ class UserSettingsDialog(QDialog):
         padding_label = QLabel("Set cell padding")
         self.padding_text_box = QLineEdit()
         self.padding_button = QPushButton("Set Padding")
+        encoding_video_label = QLabel("Encoding Video Settings:")
+        frames_skip_label = QLabel("Set number of frames to skip")
+        self.frames_skip_text_box = QLineEdit()
+        self.frames_skip_button = QPushButton("Change Number of frames to skip")
+
 
         # Adds the widgets to the internal layouts.
         minimum_size_hbox.addWidget(self.minimum_size_width_box)
@@ -38,9 +46,12 @@ class UserSettingsDialog(QDialog):
         maximum_width_hbox.addWidget(self.maximum_width_button)
         padding_hbox.addWidget(self.padding_text_box)
         padding_hbox.addWidget(self.padding_button)
+        frames_skip_hbox.addWidget(self.frames_skip_text_box)
+        frames_skip_hbox.addWidget(self.frames_skip_button)
 
         # Adds a title for the encoding table settings to the dialog.
         dialog_layout.addWidget(encoding_table_label)
+
 
         # Adds all the widgets to the main layout.
         dialog_layout.addSpacing(50)
@@ -52,6 +63,11 @@ class UserSettingsDialog(QDialog):
         dialog_layout.addSpacing(50)
         dialog_layout.addWidget(padding_label)
         dialog_layout.addLayout(padding_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addWidget(encoding_video_label)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addWidget(frames_skip_label)
+        dialog_layout.addLayout(frames_skip_hbox)
 
         # Sets the layout of the dialog.
         self.setLayout(dialog_layout)
@@ -73,4 +89,19 @@ class UserSettingsDialog(QDialog):
         Connects a padding_button event to a slot function in the controller.
         """
         self.padding_button.clicked.connect(slot)
+
+    def connect_frames_skip_to_slot(self, slot):
+        """
+        Connects a frames_skip_button event to a slot function in the controller.
+        """
+        self.frames_skip_button.clicked.connect(slot)
+
+    def get_frames_skip(self):
+        return self.frames_skip_text_box.text()
+
+    def slot_function(self):
+        frames_skip = self.get_frames_skip()
+        print("Number of frames to skip:", frames_skip)
+
+
     

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -17,8 +17,8 @@ class UserSettingsDialog(QDialog):
         maximum_width_hbox = QHBoxLayout()
         padding_hbox = QHBoxLayout()
 
-        # Create a new horizontal layout for the "Number of frames to skip" setting
-        frames_skip_hbox = QHBoxLayout()
+        # Create a new horizontal layout for the "Number of seconds to skip" setting
+        seconds_skip_hbox = QHBoxLayout()
 
         # Initializes the widgets of the dialog.
         encoding_table_label = QLabel("Encoding Table Settings:")
@@ -33,9 +33,9 @@ class UserSettingsDialog(QDialog):
         self.padding_text_box = QLineEdit()
         self.padding_button = QPushButton("Set Padding")
         encoding_video_label = QLabel("Encoding Video Settings:")
-        frames_skip_label = QLabel("Set number of frames to skip")
-        self.frames_skip_text_box = QLineEdit()
-        self.frames_skip_button = QPushButton("Change Number of frames to skip")
+        seconds_skip_label = QLabel("Set number of seconds to skip")
+        self.seconds_skip_text_box = QLineEdit()
+        self.seconds_skip_button = QPushButton("Change Number of seconds to skip")
 
 
         # Adds the widgets to the internal layouts.
@@ -46,8 +46,8 @@ class UserSettingsDialog(QDialog):
         maximum_width_hbox.addWidget(self.maximum_width_button)
         padding_hbox.addWidget(self.padding_text_box)
         padding_hbox.addWidget(self.padding_button)
-        frames_skip_hbox.addWidget(self.frames_skip_text_box)
-        frames_skip_hbox.addWidget(self.frames_skip_button)
+        seconds_skip_hbox.addWidget(self.seconds_skip_text_box)
+        seconds_skip_hbox.addWidget(self.seconds_skip_button)
 
         # Adds a title for the encoding table settings to the dialog.
         dialog_layout.addWidget(encoding_table_label)
@@ -66,8 +66,8 @@ class UserSettingsDialog(QDialog):
         dialog_layout.addSpacing(50)
         dialog_layout.addWidget(encoding_video_label)
         dialog_layout.addSpacing(50)
-        dialog_layout.addWidget(frames_skip_label)
-        dialog_layout.addLayout(frames_skip_hbox)
+        dialog_layout.addWidget(seconds_skip_label)
+        dialog_layout.addLayout(seconds_skip_hbox)
 
         # Sets the layout of the dialog.
         self.setLayout(dialog_layout)
@@ -90,18 +90,8 @@ class UserSettingsDialog(QDialog):
         """
         self.padding_button.clicked.connect(slot)
 
-    def connect_frames_skip_to_slot(self, slot):
+    def connect_seconds_skip_to_slot(self, slot):
         """
-        Connects a frames_skip_button event to a slot function in the controller.
+        Connects a seconds_skip_button event to a slot function in the controller.
         """
-        self.frames_skip_button.clicked.connect(slot)
-
-    def get_frames_skip(self):
-        return self.frames_skip_text_box.text()
-
-    def slot_function(self):
-        frames_skip = self.get_frames_skip()
-        print("Number of frames to skip:", frames_skip)
-
-
-    
+        self.seconds_skip_button.clicked.connect(slot)

--- a/main.py
+++ b/main.py
@@ -21,6 +21,8 @@ def main():
     start_dialog = StartDialog()
     dialog_choice = start_dialog.exec()
 
+
+
     # If the user rejected the start dialog box, then exit.
     if dialog_choice == 0:
         return


### PR DESCRIPTION
This patch adds forward and backward buttons to skip the number of seconds specified by the user in the settings. The default time skip is 5 seconds.

This patch also adds an input to the media control panel to jump to specified timestamp by the user.

Testing Steps
 1. Run then application
 2. Create a new session
 3. Load a video
 4. Click the forward and backward buttons to verify the default value
 5. Go to the settings and change the time skip to 3 seconds.
 6. Click the forward and backward buttons to verify the new skip value
 7. Enter some value in the timestamp input to verify the video goes to the specified timestamp

Type: New Feature