### PR TITLE
Added functionality to delete selected row/column

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -3,7 +3,6 @@ import sys
 from PySide6.QtCore import Slot, QMimeDatabase
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
 from PySide6.QtWidgets import QFileDialog, QDialog, QStyle
-
 from View.user_settings_dialog import UserSettingsDialog
 
 
@@ -56,11 +55,6 @@ class Controller:
         self._window.table_panel.table.horizontalHeader(
         ).line.editingFinished.connect(self.done_editing)
 
-        self._window.table_panel.add_col_button.clicked.connect(
-            self.add_col_to_encoding_table)
-        self._window.table_panel.add_row_button.clicked.connect(
-            self.add_row_to_encoding_table)
-
         self._window.media_panel.media_control_panel.play_pause_button.clicked.connect(
             self.play_video)
 
@@ -82,6 +76,8 @@ class Controller:
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
         self._window.table_panel.add_row_button.clicked.connect(self.add_row_to_encoding_table)
+        self._window.table_panel.delete_col_button.clicked.connect(self.del_current_column)
+        self._window.table_panel.delete_row_button.clicked.connect(self.del_current_row)
 
     @Slot()
     def add_col_to_encoding_table(self):
@@ -92,6 +88,16 @@ class Controller:
     def add_row_to_encoding_table(self):
         """ Command the table widget to add a row. """
         self._window.table_panel.table.add_row()
+
+    @Slot()
+    def del_current_column(self):
+        """ Command the table widget to delete current selected column"""
+        self._window.table_panel.table.del_column()
+
+    @Slot()
+    def del_current_row(self):
+        """ Command the table widget to delete current selected row"""
+        self._window.table_panel.table.del_row()
 
     @Slot()
     def change_font_of_encoding_table(self):

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -105,7 +105,7 @@ class EncodingTable(QTableWidget):
                 col1 = item_list[0].column()
                 row2 = item_list[1].row()
                 col2 = item_list[1].column()
-                print( row1, row1, col1, col2)
+                
                 if row1 == row2 and col1 != col2:
                     row = True
                 if row1 != row2 and col1 == col2:

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -83,9 +83,37 @@ class EncodingTable(QTableWidget):
         """
         Deletes current selected row
         """
+
         if self.rowCount() > 1:
             current_row = self.currentRow()
-            if current_row != 0:
+            item_list = self.selectedIndexes()
+            num_columns = self.columnCount()
+            num_rows = self.rowCount()
+            row = False
+            col = False
+
+            # This logic determines whether a column or a row is selected
+            if num_columns == 1:
+                if len(item_list) == 0:
+                    return
+                elif len(item_list) == num_rows:
+                    col = True
+                else:
+                    row = True
+            elif len(item_list) > 1:
+                row1 = item_list[0].row()
+                col1 = item_list[0].column()
+                row2 = item_list[1].row()
+                col2 = item_list[1].column()
+                print( row1, row1, col1, col2)
+                if row1 == row2 and col1 != col2:
+                    row = True
+                if row1 != row2 and col1 == col2:
+                    col = True
+
+            if current_row == -1 or col:
+                return
+            elif row:
                 self.removeRow(current_row)
 
     def change_font(self, font_choice):

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -1,6 +1,7 @@
-from PySide6.QtCore import QSettings
+from PySide6.QtCore import QSettings, QObject, QItemSelectionModel
 from PySide6.QtWidgets import QTableWidget, QTableWidgetItem, QLineEdit
 from PySide6 import QtWidgets, QtCore
+
 
 
 class EncodingTable(QTableWidget):
@@ -68,6 +69,24 @@ class EncodingTable(QTableWidget):
         Increases the row count of the table by 1.
         """
         self.setRowCount(self.rowCount() + 1)
+
+    def del_column(self):
+        """
+        Deletes current selected column
+        """
+        if self.columnCount() > 1:
+            current_col = self.currentColumn()
+            if current_col != 0:
+                self.removeColumn(current_col)
+
+    def del_row(self):
+        """
+        Deletes current selected row
+        """
+        if self.rowCount() > 1:
+            current_row = self.currentRow()
+            if current_row != 0:
+                self.removeRow(current_row)
 
     def change_font(self, font_choice):
         """

--- a/View/table_panel.py
+++ b/View/table_panel.py
@@ -39,14 +39,14 @@ class TablePanel(QWidget):
         self.change_font_dropDown.addItems(font_options)
 
         grid_layout = QGridLayout()
-        grid_layout.addWidget(self.table, 0, 0)
-        grid_layout.addWidget(self.add_col_button, 0, 1, alignment=Qt.AlignCenter)
-        grid_layout.addWidget(self.add_row_button, 0, 1, alignment=Qt.AlignBottom)
-        grid_layout.addWidget(self.change_font_label, 0, 1, alignment=Qt.AlignTop)
-        grid_layout.addWidget(self.change_font_dropDown, 0, 2, alignment=Qt.AlignTop|Qt.AlignLeft)
-        grid_layout.addWidget(self.delete_col_button, 0, 2, alignment=Qt.AlignCenter)
-        grid_layout.addWidget(self.delete_row_button, 0, 2, alignment=Qt.AlignBottom)
-
+        grid_layout.addWidget(self.title, 0, 0, QtCore.Qt.AlignCenter)
+        grid_layout.addWidget(self.table, 1, 0)
+        grid_layout.addWidget(self.add_col_button, 1, 1, alignment=Qt.AlignCenter)
+        grid_layout.addWidget(self.add_row_button, 1, 1, alignment=Qt.AlignBottom)
+        grid_layout.addWidget(self.change_font_label, 1, 1, alignment=Qt.AlignTop)
+        grid_layout.addWidget(self.change_font_dropDown, 1, 2, alignment=Qt.AlignTop|Qt.AlignLeft)
+        grid_layout.addWidget(self.delete_col_button, 1, 2, alignment=Qt.AlignCenter)
+        grid_layout.addWidget(self.delete_row_button, 1, 2, alignment=Qt.AlignBottom)
         self.setLayout(grid_layout)
 
     def read_settings(self, session_id):

--- a/View/table_panel.py
+++ b/View/table_panel.py
@@ -1,6 +1,7 @@
 
 from PySide6.QtWidgets import QWidget, QPushButton, QGridLayout, QSizePolicy, QComboBox, QLabel
 from View.encoding_table import EncodingTable
+from PySide6.QtCore import Qt
 
 
 class TablePanel(QWidget):
@@ -17,6 +18,8 @@ class TablePanel(QWidget):
 
         self.add_col_button = QPushButton("Add column")
         self.add_row_button = QPushButton("Add row")
+        self.delete_col_button = QPushButton("Delete current column")
+        self.delete_row_button = QPushButton("Delete current row")
 
         # Configure the add column button to expand vertically.
         self.add_col_button.setSizePolicy(
@@ -32,9 +35,11 @@ class TablePanel(QWidget):
 
         grid_layout = QGridLayout()
         grid_layout.addWidget(self.table, 0, 0)
-        grid_layout.addWidget(self.add_col_button, 1, 1)
-        grid_layout.addWidget(self.add_row_button, 1, 0)
-        grid_layout.addWidget(self.change_font_label, 0, 1)
-        grid_layout.addWidget(self.change_font_dropDown, 0, 2)
+        grid_layout.addWidget(self.add_col_button, 0, 1, alignment=Qt.AlignCenter)
+        grid_layout.addWidget(self.add_row_button, 0, 1, alignment=Qt.AlignBottom)
+        grid_layout.addWidget(self.change_font_label, 0, 1, alignment=Qt.AlignTop)
+        grid_layout.addWidget(self.change_font_dropDown, 0, 2, alignment=Qt.AlignTop|Qt.AlignLeft)
+        grid_layout.addWidget(self.delete_col_button, 0, 2, alignment=Qt.AlignCenter)
+        grid_layout.addWidget(self.delete_row_button, 0, 2, alignment=Qt.AlignBottom)
 
         self.setLayout(grid_layout)


### PR DESCRIPTION
Added a delete row and delete column button to delete selected row/column.

In this patch, a user can select a row or column and then press the "delete selected row" or "delete selected column" button to delete the selected row/column. The buttons also work if a user selects a specific cell instead of a whole row/column. The first row and first column cannot be deleted currently. 

Testing Steps

1. Run main.py to start the application.
2. Select a column (not the first) and press the delete column button, make sure column is deleted.
3. Select the first column, press the delete button, and make sure it is NOT deleted.
4. Select a row (not the first) and press the delete row button make sure row is deleted
5. Select the first row and press the delete row button, make sure row is NOT deleted.
6. Select a row and click the delete column button, make sure nothing is deleted.
7. Select a column and click the delete row button, make sure nothing is deleted.

Type: New Feature