### PR TITLE
Fixes table title width when prev session is read

### DIFF
--- a/Controllers/controller.py
+++ b/Controllers/controller.py
@@ -84,6 +84,11 @@ class Controller:
         if self._window.session_id == "New Session":
             self.establish_table_title()
 
+        # Resizes the title bar of the encoding table, this is triggered
+        #   manually here since the slot was not connected to the encoding
+        #   table when its title was initialized.
+        self.resize_to_content()
+
     @Slot()
     def add_col_to_encoding_table(self):
         """ Command the table widget to add a column. """


### PR DESCRIPTION
This patch fixes a bug, where the width of the encoding table does not fit longer table names from saved sessions. This bug occurred because the controller's resizing slot was not connected to the table panel upon the initialization of the tabel panel. This patch manually triggers the slot function when the controller is instantiated, essentially "catching up"

Testing Steps:
  1. Run the application
  2. Create a new session
  3. Set a long encoding table title (more than 50 characters)
  4. Close and reload the session
  5. Verify that the title width fits the title

Type: Bug Fix