### PR TITLE
Updates the encoding button panel layout to 3x3

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -472,7 +472,7 @@ class WindowController:
             if check_button_name == button_definition.button_id:
                 if button_definition.hotkey in self._manager.hotkey_list:
                     self._manager.hotkey_list.remove(button_definition.hotkey)
-                self._window.coding_assistance_panel.button_panel.delete_coding_assistance_button(check_button_name)
+                self._window.coding_assistance_panel.button_panel.delete_coding_assistance_button(button_definition)
 
     def dynamic_button_click(self):
         """Add dummy data to table"""

--- a/View/button_panel.py
+++ b/View/button_panel.py
@@ -2,6 +2,8 @@ from PySide6.QtCore import QObject
 from PySide6.QtGui import QKeySequence
 from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QSizePolicy, QGridLayout, QHBoxLayout
 
+from View.grid_layout import GridLayout
+
 
 class ButtonPanel(QWidget):
     """Container of all Coding Assistance buttons."""
@@ -14,12 +16,14 @@ class ButtonPanel(QWidget):
         super().__init__()
 
         button_container = QWidget()
-        add_delete_container = QWidget()
+
         self.button_layout = QGridLayout()
         self.add_delete_layout = QHBoxLayout()
 
+        self.horizontal_layout = QHBoxLayout()
         self.add_button = QPushButton("+")
         self.delete_button = QPushButton("-")
+        add_delete_container = QWidget()
 
         self.add_button.setSizePolicy(
             QSizePolicy.Preferred,
@@ -32,11 +36,11 @@ class ButtonPanel(QWidget):
         self.add_delete_layout.addWidget(self.add_button)
         self.add_delete_layout.addWidget(self.delete_button)
 
-        button_container.setLayout(self.button_layout)
         add_delete_container.setLayout(self.add_delete_layout)
 
         # Add css styling to the container to give it a background color.
         button_container.setProperty("class", "button-container")
+        add_delete_container.setProperty("class", "add_delete_container")
         self.setStyleSheet('''
             .button-container {
                 background-color: #c5cbd4;
@@ -45,18 +49,30 @@ class ButtonPanel(QWidget):
             }
         ''')
 
-        add_delete_container.setProperty("class", "add_delete_container")
-        self.setStyleSheet('''
-             .add_delete_container {
-                 background-color: #c5cbd4;
-                 border: 1px solid black;
-                 border-radius: 5%;
-            }
-        ''')
+        # Layout for the button container widget.
+        self.vertical_layout = QVBoxLayout()
+        self.vertical_layout.setContentsMargins(0, 0, 0, 0)
 
-        self.setLayout(QVBoxLayout())
-        self.layout().addWidget(button_container)
-        self.layout().addWidget(add_delete_container)
+        # Create a 3x3 grid for the encoding buttons.
+        grid_container = QWidget()
+        self.grid_layout = GridLayout(self.parent(), 3, 3)
+        grid_container.setLayout(self.grid_layout)
+        grid_container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        self.add_button = QPushButton("+")
+        self.add_button.setSizePolicy(
+            QSizePolicy.Preferred,
+            QSizePolicy.Expanding)
+
+        self.horizontal_layout.addWidget(self.add_button)
+        self.horizontal_layout.addWidget(self.delete_button)
+        button_container.setLayout(self.horizontal_layout)
+
+        self.vertical_layout.addWidget(grid_container, stretch=10)
+        self.vertical_layout.addWidget(button_container, stretch=1)
+
+        # Add the button container to the button panel.
+        self.setLayout(self.vertical_layout)
 
     def connect_add_button_to_slot(self, slot):
         """
@@ -71,13 +87,21 @@ class ButtonPanel(QWidget):
         self.delete_button.clicked.connect(slot)
 
     def create_coding_assistance_button(self, button_definition):
-        """Adds a new_button to the Coding Assistance Panel"""
-        self.button_layout.addWidget(button_definition.button)
+        """
+        Adds a new_button to the Coding Assistance Panel
 
+        Parameters:
+            button_definition - definition of button to create.
+        """
+        button = button_definition.button
+        button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.grid_layout.addWidget(button)
 
-    def delete_coding_assistance_button(self, button_name):
-        """Deletes a button in the Coding Assistance Panel"""
-        for i in range(self.button_layout.count()):
-            button = self.button_layout.itemAt(i).widget()
-            if button.objectName() == button_name:
-                button.setParent(None)
+    def delete_coding_assistance_button(self, button_definition):
+        """
+        Deletes a button in the Coding Assistance Panel
+
+        Parameters:
+            button_definition - definition of button to delete
+        """
+        self.grid_layout.removeItem(button_definition.button)

--- a/View/coding_assistance_panel.py
+++ b/View/coding_assistance_panel.py
@@ -22,16 +22,14 @@ class CodingAssistancePanel(QWidget):
 
         # Create a container widget that will encompass the panel widgets.
         panel_container = QWidget()
-        vertical_layout = QVBoxLayout()
 
-        # Create an empty widget to pad the panel.
-        empty_widget = QWidget()
+        # Create a vertical layout manager for the panel.
+        vertical_layout = QVBoxLayout()
+        vertical_layout.setContentsMargins(0, 10, 0, 0)
 
         # Add the coding assistance related widgets to a vertical layout.
-
-        vertical_layout.addWidget(self._title, stretch=1)
-        vertical_layout.addWidget(empty_widget, stretch=6)
-        vertical_layout.addWidget(self.button_panel, stretch=2)
+        vertical_layout.addWidget(self._title)
+        vertical_layout.addWidget(self.button_panel)
         panel_container.setLayout(vertical_layout)
 
         # Add css styling to give a border to the panel.

--- a/View/grid_layout.py
+++ b/View/grid_layout.py
@@ -1,0 +1,100 @@
+from PySide6.QtWidgets import QGridLayout
+
+
+class GridLayout(QGridLayout):
+    """
+    Custom QGridLayout, made to add widgets top to bottom and left to right.
+    In addition, the grid row and column sizes are constant.
+    """
+
+    def __init__(self, parent, row_count, col_count):
+        """
+        Constructs an instance of the grid layout.
+
+        Parameters:
+            parent - pointer to the parent object the layout resides in.
+            row_count - number of rows in the grid layout.
+            col_count - number of columns in the grid layout.
+        """
+        super().__init__(parent)
+        self.row_count = row_count
+        self.col_count = col_count
+
+        # Set all rows and columns to have an equal constant stretching factor.
+        for row in range(self.row_count):
+            self.setRowStretch(row, 1)
+        for col in range(self.col_count):
+            self.setColumnStretch(col, 1)
+
+    def addWidget(self, widget):
+        """
+        Adds the given widget at the insertion coordinate
+
+        Parameters:
+            widget - widget to add to the layout.
+        Exception:
+            ValueError - unable to add widget to full layout.
+        """
+        current_row = 0
+        current_col = 0
+
+        while self.itemAtPosition(current_row, current_col):
+            if current_col == (self.col_count - 1):
+                current_col = 0
+                current_row += 1
+            else:
+                current_col += 1
+
+        if current_row < self.row_count and current_col < self.col_count:
+            super().addWidget(widget, current_row, current_col)
+        else:
+            raise ValueError("Unable to add widget to GridLayout. Layout is full.")
+
+    def removeItem(self, widget):
+        """
+        Removes the widget from the grid layout, shifting all elements over to fill
+        the gap.
+
+        Parameters:
+            widget - widget to remove
+        """
+        current_row = 0
+        current_col = 0
+        while self.itemAtPosition(current_row, current_col) and \
+                self.itemAtPosition(current_row, current_col).widget() is not widget:
+            if current_col == (self.col_count - 1):
+                current_col = 0
+                current_row += 1
+            else:
+                current_col += 1
+
+        if self.itemAtPosition(current_row, current_col) and self.itemAtPosition(current_row, current_col).widget() is widget:
+            self.itemAtPosition(current_row, current_col).widget().hide()
+            super().removeItem(self.itemAtPosition(current_row, current_col))
+            self._shift_widgets_left(current_row, current_col)
+
+    def _shift_widgets_left(self, row, col):
+        """
+        Shifts all widgets following slot at given (row, col) over to the left one spot.
+
+        Parameters:
+            row - row of slot to start shifting
+            col - col of slot to start shifting
+        """
+        current_row = row
+        current_col = col
+
+        next_row = row if col != self.columnCount() - 1 else row + 1
+        next_col = col + 1 if col != self.columnCount() - 1 else 0
+
+        while self.itemAtPosition(next_row, next_col):
+            super().addWidget(self.itemAtPosition(next_row, next_col).widget(), current_row, current_col)
+            self.removeItem(self.itemAtPosition(next_row, next_col))
+            current_row = next_row
+            current_col = next_col
+
+            if next_col == (self.col_count - 1):
+                next_col = 0
+                next_row += 1
+            else:
+                next_col += 1


### PR DESCRIPTION
Before this change, encoding buttons were added in a vertical layout manager in the button panel. With this change, buttons are added in a 3x3 grid. The buttons are added from top to bottom, left to right.

Testing Steps:
  1. Run the application and create a new session
  2. For each number, x, in the range of 1-9, click on the add encoding button, "+", in the encoding panel, and add a button with a label of "test button x" and shortcut "x". Verify that the buttons are added in a 3x3 grid, from top to bottom, left to right.
  3. Verify that the row and column size did not change throughout step 2
  4. Add another button of any unique label and shortcut, and verify that a ValueError is thrown in the console.

Type: New Feature