### PR TITLE
Fixes lowercase session id bug

### DIFF
--- a/Controllers/project_management_controller.py
+++ b/Controllers/project_management_controller.py
@@ -93,14 +93,15 @@ class ProjectManagementController:
     @staticmethod
     def is_unique_session_name(session_name):
         """
-        Determines whether the session_id has been previously stored.
+        Determines whether the session_id has been previously stored (case-insensitive).
 
         Return:
             True if the session_id has been previously stored, False otherwise.
         """
         settings = QSettings()
+        session_name = session_name.lower()
         for session in settings.childGroups():
-            if session.title() == session_name:
+            if session.lower() == session_name:
                 return False
         return True
 

--- a/View/main_window.py
+++ b/View/main_window.py
@@ -104,7 +104,7 @@ class MainWindow(QMainWindow):
         """
         settings = QSettings()
         for session in settings.childGroups():
-            if session.title() == session_id:
+            if session == session_id:
                 return True
         return False
 

--- a/View/session_manager_page.py
+++ b/View/session_manager_page.py
@@ -90,7 +90,7 @@ class SessionManagerPage(QDialog):
         # Get access to stored session data
         settings = QSettings()
         for session_id in settings.childGroups():
-            session_option = SessionOption(session_id.title())
+            session_option = SessionOption(session_id)
             vertical_layout.addWidget(session_option)
 
         vertical_layout.addStretch()

--- a/View/start_dialog.py
+++ b/View/start_dialog.py
@@ -56,7 +56,7 @@ class StartDialog(QDialog):
         """
         settings = QSettings()
         for group in settings.childGroups():
-            button = QPushButton(group.title())
+            button = QPushButton(group)
             self.button_container.addButton(button)
 
     @Slot()


### PR DESCRIPTION
Before this change, all session ID values written through QSettings were titleized, using python's title() method. This prevented the user from creating a session with a lowercase session ID, as it would not equal its titleized counterpart. This patch removes the title() method, allowing the session ID to be written as is, and consequently allows for session IDs of all cases.

This patch also updates the check for session ID uniqueness to be case-insensitive. This change is to support all platforms, as the Windows registry uses case-insensitive keys.

Testing Steps:
  1. Run the application and clear all sessions
  2. Create a new session and give it an ID="test"
  3. Write dummy data in the encoding table
  4. Restart the application and verify that the session in the welcome screen is labeled "test" and not "Test"
  5. Load the "test" session and verify the dummy data has persisted
  6. Restart the application
  7. Attempt to create a new session called "Test", and verify it is not allowed
  8. Repeat steps 1-5, but with a new session ID="Test"

Type: Bug Fix