### PR TITLE
Adds session persistence to encoding buttons

### DIFF
--- a/Application/button_manager.py
+++ b/Application/button_manager.py
@@ -1,0 +1,73 @@
+class ButtonManager:
+    """
+    ButtonManager is a manager for the current session that saves all
+    active button hotkeys and button definitions. It also provides
+    functionality to save the button data to file, using QSettings.
+    """
+
+    def __init__(self):
+        """
+        Constructs an instance of the ButtonManager manager class.
+        """
+        self.hotkey_map = {}      # id : hotkey
+        self.definition_map = {}  # id : button definition
+
+    def add_button_definition(self, identifier, button_definition):
+        """
+        Maps the button identifier to its button definition in storage.
+
+        Parameters:
+            identifier - identifier of button
+            button_definition - definition of button
+        """
+        self.definition_map[identifier] = button_definition
+
+    def add_button_hotkey(self, identifier, hotkey):
+        """
+        Maps the button identifier to its hotkey
+
+        Parameters:
+            identifier - identifier of button
+            hotkey - hotkey of button
+        """
+        self.hotkey_map[identifier] = hotkey
+
+    def get_button_data(self):
+        """
+        Get a list of all active encoding button data.
+
+        Returns:
+            List of (hotkey, definition) pairs of all active encoding buttons.
+        """
+        button_data = []
+        for identifier in self.hotkey_map.keys():
+            button_data_pair = (self.hotkey_map[identifier], self.definition_map[identifier])
+            button_data.append(button_data_pair)
+        return button_data
+
+    def get_hotkeys(self):
+        """
+        Gets all active hotkeys for encoding buttons
+
+        Returns:
+            List of all active hotkeys
+        """
+        return list(self.hotkey_map.values())
+
+    def remove_button_definition(self, identifier):
+        """
+        Removes the definition associated to the given button identifier.
+
+        Parameters:
+            identifier - identifier of button to remove definition of.
+        """
+        del self.definition_map[identifier]
+
+    def remove_button_hotkey(self, identifier):
+        """
+        Removes the hotkey associated to the given button identifier.
+
+        Parameters:
+            identifier - identifier of button to remove hotkey of.
+        """
+        del self.hotkey_map[identifier]

--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -29,12 +29,6 @@ class GlobalSettingsManager:
         self.global_settings_entity.button_definitions.remove(button_definition)
         self.update_saved_settings()
 
-    def get_button_hotkeys(self):
-        """
-        Return the list of button hotkeys from the button definition list
-        """
-        return [button_definition.hotkey for button_definition in self.global_settings_entity.button_definitions]
-
     def get_button_definition(self, button_id):
         """
         Return a button definition from the button definition list
@@ -57,7 +51,6 @@ class GlobalSettingsManager:
         for index, button_definition in enumerate(self.global_settings_entity.button_definitions):
             settings.setArrayIndex(index)
             settings.setValue("button-id", button_definition.button_id)
-            settings.setValue("hotkey", button_definition.hotkey)
             settings.beginWriteArray("data", len(button_definition.data))
             for data_index, data_item in enumerate(button_definition.data):
                 settings.setArrayIndex(data_index)
@@ -81,14 +74,13 @@ class GlobalSettingsManager:
         for index in range(button_definitions_length):
             settings.setArrayIndex(index)
             button_id = settings.value("button-id")
-            hotkey = settings.value("hotkey")
             data = []
             data_length = settings.beginReadArray("data")
             for data_index in range(data_length):
                 settings.setArrayIndex(data_index)
                 data.append(settings.value("data-item"))
             settings.endArray()
-            button_definition = ButtonDefinitionEntity(button_id, hotkey, data)
+            button_definition = ButtonDefinitionEntity(button_id, data)
             self.global_settings_entity.button_definitions.append(button_definition)
         settings.endArray()
 

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -81,6 +81,10 @@ class StateController:
         self.window.table_panel.table.set_headers(self.session_manager.session_entity.table_headers)
         self.window.table_panel.table.set_table_data(self.session_manager.session_entity.table_data)
 
+        button_data = self.session_manager.session_entity.button_definitions
+        for hotkey, definition in button_data:
+            self.window_controller.create_button(hotkey, definition)
+
     @Slot()
     def open_session_creator_page(self):
         """
@@ -123,6 +127,9 @@ class StateController:
 
         table_data = self.window.table_panel.table.get_table_data()
         self.session_manager.set_table_data(table_data)
+
+        button_definitions = self.window_controller.button_manager.get_button_data()
+        self.session_manager.set_button_definitions(button_definitions)
 
         # Call function to write everything to QSettings.
         self.session_manager.write_to_settings()

--- a/Models/button_definition_entity.py
+++ b/Models/button_definition_entity.py
@@ -6,10 +6,13 @@ class ButtonDefinitionEntity:
     An object defining the attributes for a button within the coding assistance
     panel.
     """
-    def __init__(self, button_id, hotkey, data):
+    def __init__(self, button_id, data):
         """
         Constructor - Creates an instance of ButtonDefinitionEntity
+
+        Parameters:
+            button_id - identifier of button
+            data - button definition of button
         """
         self.button_id = button_id
-        self.hotkey = hotkey
         self.data = data

--- a/Models/session_entity.py
+++ b/Models/session_entity.py
@@ -14,6 +14,7 @@ class SessionEntity:
         table rows, table columns, table headers, and table data.
         """
         self.session_id = ""
+        self.button_definitions = []
         self.table_name = ""
         self.table_row_count = 0
         self.table_col_count = 0

--- a/View/button_panel.py
+++ b/View/button_panel.py
@@ -96,15 +96,15 @@ class ButtonPanel(QWidget):
         button.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.grid_layout.addWidget(button)
 
-    """def delete_coding_assistance_button(self, button_definition):
-        
+    def delete_coding_assistance_button(self, button_id):
+        """
         Deletes a button in the Coding Assistance Panel
 
         Parameters:
-            button_definition - definition of button to delete
-        
-        for i in range(self.button_layout.count()):
-            button = self.grid_layout.itemAt(i).widget()
-            if button.text() == button_definition.button_id:
-                self.grid_layout.removeItem(button)
-                return"""
+            button_id - identifier of button to delete
+        """
+        button_widgets = self.grid_layout.widgets()
+        for button_widget in button_widgets:
+            if button_widget.text() == button_id:
+                self.grid_layout.removeItem(button_widget)
+                break

--- a/View/grid_layout.py
+++ b/View/grid_layout.py
@@ -73,6 +73,27 @@ class GridLayout(QGridLayout):
             super().removeItem(self.itemAtPosition(current_row, current_col))
             self._shift_widgets_left(current_row, current_col)
 
+    def widgets(self):
+        """
+        Returns a list of all widgets in the grid layout.
+
+        Returns:
+            List of all widgets in the grid layout.
+        """
+        widgets = []
+        current_row = current_col = 0
+
+        while self.itemAtPosition(current_row, current_col):
+            widget = self.itemAtPosition(current_row, current_col).widget()
+            widgets.append(widget)
+            if current_col == (self.col_count - 1):
+                current_col = 0
+                current_row += 1
+            else:
+                current_col += 1
+
+        return widgets
+
     def _shift_widgets_left(self, row, col):
         """
         Shifts all widgets following slot at given (row, col) over to the left one spot.

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -15,10 +15,7 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         self.checkboxes = []
 
         for button_definition in button_definitions:
-            checkbox = QCheckBox("Button Name: " +
-                                 button_definition.button_id +
-                                 " Button Hotkey: " +
-                                 button_definition.hotkey)
+            checkbox = QCheckBox("Button Name: " + button_definition.button_id)
             self.checkboxes.append(checkbox)
             dialog_layout.addWidget(checkbox)
 


### PR DESCRIPTION
This patch adds session persistence to encoding buttons. This means that all encoding buttons in the button panel are saved at the session level. When the session is loaded again, the buttons are automatically loaded with their assigned hotkeys.

This patch also adds back support for encoding button removal. If a button is removed, and the session is exited, then the button does not persist.

Additionally, this patch removes hotkeys from global settings. Buttons loaded at the global settings level do not have assigned hotkeys, as hotkeys are a session level piece of data. The functionality to assign hotkeys to loaded global button definitions should be added in a future patch.

Testing Steps:
  1. Run the application and clear all sessions
  2. Create a new session, "Session A"
  3. Create three buttons, "button 1", "button 2", and "button 3", with hotkeys "a", "b", "c", and dummy data. Save the buttons globally
  4. Verify that the button functionality works as expected
  5. Repeat steps 2-4, but with "Session B", and "button 4", "button 5", and "button 6", dummy data, and the same hotkeys
  6. Load "Session A"
  7. Verify that buttons 1-3 are loaded, and the functionality works as expected
  8. Repeat steps 6-7, but with "Session B"
  9. Create a new session, "Session C"
  10. Load "button 1"
  11. Reload "Session C" and verify the button persists and functionality works as expected
  12. Load "Session A"
  13. Remove "button 2" and verify its removed from the panel
  14. Verify the hotkey "b" does not do anything
  15. Reload "Session A" and verify "button 2" is gone

Type: New Feature