### PR TITLE
Dev display current time bug fix

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -83,13 +83,8 @@ class WindowController:
             playback_speed_combo_box.currentIndexChanged.connect(
                 self.set_playback_speed)
 
-        self.total_time_in_secs = 0
-        self.curr_time_secs = 0
-        self.curr_time_minutes = 0
-        self.curr_time_hours = 0
-        self.time_back_secs = 0
-        self.time_count = 0
-        self.max_time_back = 0
+        # Holds the time for the loaded video in ms.
+        self.current_time = 0
         self._media_player.positionChanged.connect(self.get_video_time_total)
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
@@ -173,8 +168,7 @@ class WindowController:
         """
         # Get the total time of the video in milliseconds.
         total_in_ms = self._media_player.duration()
-        current_time = self._media_player.position()
-        #print(current_time, "before conversion")
+        self.current_time = self._media_player.position()
 
         # This convert to seconds, minutes, hours, and frames
         # and rounds down to the nearest value.
@@ -200,52 +194,16 @@ class WindowController:
         total_time_str = f"{hours_rounded_down:02d}:{minutes_rounded_down:02d}:{sec_rounded_down:02d}"
 
         # This gets the current time in seconds.
-        temp = self.total_time_in_secs
-        current_time = current_time - (1000 * self.total_time_in_secs)
-        #print(temp, "total time in sec")
-        #print(current_time, "after conversion")
-        if current_time > 1000:
-            self.total_time_in_secs += 1
-            self.curr_time_secs += 1
-            if self.curr_time_secs > 60:
-                self.curr_time_secs = 0
-                self.curr_time_minutes += 1
-                if self.curr_time_minutes > 60:
-                    self.curr_time_minutes = 0
-                    self.curr_time_hours += 1
-        elif current_time < 0:
-            binned_time = current_time - (current_time % -temp)
-            self.time_back_secs = int(binned_time / 1000)
-            print(self.time_back_secs, "time back")
-            if self.time_back_secs < self.max_time_back:
-                self.curr_time_secs -= self.max_time_back
-                self.max_time_back = self.time_back_secs
-                self.curr_time_secs += self.max_time_back
-                #print(self.curr_time_secs, "curr time secs")
-                #print(self.max_time_back, "max time back")
-                #print("")
-            else:
-                self.time_count += 1
-                print(self.time_count, "count")
-                print(binned_time, "binned time")
-                if self.time_count == 10:
-                    print("increment")
-                    self.time_count = 0
+        current_seconds = (self.current_time / 1000) % 60
+        current_seconds = int(current_seconds)
+        current_minutes = (self.current_time / (1000 * 60)) % 60
+        current_minutes = int(current_minutes)
+        current_hours = (self.current_time / (1000 * 60 * 60)) % 24
+        current_hours = int(current_hours)
 
-            """
-            self.time_back_secs = int(binned_time/1000)
-            self.curr_time_secs += self.time_back_secs
-            #self.time_flag = True
-            print(self.curr_time_secs, "secs")
-            print(int(binned_time/1000), "back")
-            if binned_time < temp * 60:
-                self.curr_time_minutes += int((binned_time/1000) * 60)
-                if binned_time < temp * 360:
-                    self.curr_time_hours += int(((binned_time/1000) * 60) * 60)
-            """
         # Formats the time displaying current time/ total time
         # and then sets the text label in the media control panel.
-        time_str_formatted = f"Time: {self.curr_time_hours:02d}:{self.curr_time_minutes:02d}:{self.curr_time_secs:02d}" \
+        time_str_formatted = f"Time: {current_hours:02d}:{current_minutes:02d}:{current_seconds:02d}" \
                              f"/{total_time_str}"
         self._window.media_panel.media_control_panel.time_stamp.setText(time_str_formatted)
 

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -88,7 +88,7 @@ class WindowController:
         self.curr_time_minutes = 0
         self.curr_time_hours = 0
         self.time_back_secs = 0
-        self.time_flag = False
+        self.time_count = 0
         self.max_time_back = 0
         self._media_player.positionChanged.connect(self.get_video_time_total)
 
@@ -174,10 +174,7 @@ class WindowController:
         # Get the total time of the video in milliseconds.
         total_in_ms = self._media_player.duration()
         current_time = self._media_player.position()
-        print(current_time, "before conversion")
-        """
-        move this stuff to an entity, use the current time conversion below
-        """
+        #print(current_time, "before conversion")
 
         # This convert to seconds, minutes, hours, and frames
         # and rounds down to the nearest value.
@@ -205,9 +202,8 @@ class WindowController:
         # This gets the current time in seconds.
         temp = self.total_time_in_secs
         current_time = current_time - (1000 * self.total_time_in_secs)
-        print(current_time, "after conversion")
-        #print(self.total_time_in_secs, "seconds")
-        #print(current_time, "ms")
+        #print(temp, "total time in sec")
+        #print(current_time, "after conversion")
         if current_time > 1000:
             self.total_time_in_secs += 1
             self.curr_time_secs += 1
@@ -220,26 +216,21 @@ class WindowController:
         elif current_time < 0:
             binned_time = current_time - (current_time % -temp)
             self.time_back_secs = int(binned_time / 1000)
-            #print(self.time_back_secs)
-            #print(self.max_time_back)
+            print(self.time_back_secs, "time back")
             if self.time_back_secs < self.max_time_back:
                 self.curr_time_secs -= self.max_time_back
                 self.max_time_back = self.time_back_secs
                 self.curr_time_secs += self.max_time_back
-                #print("inside")
+                #print(self.curr_time_secs, "curr time secs")
+                #print(self.max_time_back, "max time back")
+                #print("")
             else:
-                """
-                if current_time < 1000:
-                    self.total_time_in_secs += 1
-                    self.curr_time_secs += 1
-                    if self.curr_time_secs > 60:
-                        self.curr_time_secs = 0
-                        self.curr_time_minutes += 1
-                        if self.curr_time_minutes > 60:
-                            self.curr_time_minutes = 0
-                            self.curr_time_hours += 1
-                """
-                #print("outside")
+                self.time_count += 1
+                print(self.time_count, "count")
+                print(binned_time, "binned time")
+                if self.time_count == 10:
+                    print("increment")
+                    self.time_count = 0
 
             """
             self.time_back_secs = int(binned_time/1000)

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -89,6 +89,7 @@ class WindowController:
         self.curr_time_hours = 0
         self.time_back_secs = 0
         self.time_flag = False
+        self.max_time_back = 0
         self._media_player.positionChanged.connect(self.get_video_time_total)
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
@@ -211,21 +212,41 @@ class WindowController:
                 if self.curr_time_minutes > 60:
                     self.curr_time_minutes = 0
                     self.curr_time_hours += 1
-        elif current_time < 0 and self.time_flag is False:
-            #temp = -1000
+        elif current_time < 0:
             binned_time = current_time - (current_time % -temp)
-            print(binned_time, "bin_in_ms")
-            if binned_time < temp:
-                self.time_back_secs = int(binned_time/1000)
-                self.curr_time_secs += self.time_back_secs
-                self.time_flag = True
-                print(self.curr_time_secs, "secs")
-                print(int(binned_time/1000), "back")
-                """if binned_time < temp * 60:
-                    self.curr_time_minutes += int((binned_time/1000) * 60)
-                    if binned_time < temp * 360:
-                        self.curr_time_hours += int(((binned_time/1000) * 60) * 60)"""
+            self.time_back_secs = int(binned_time / 1000)
+            print(self.time_back_secs)
+            print(self.max_time_back)
+            if self.time_back_secs < self.max_time_back:
+                self.curr_time_secs -= self.max_time_back
+                self.max_time_back = self.time_back_secs
+                self.curr_time_secs += self.max_time_back
+                print("inside")
+            else:
+                """
+                if current_time < 1000:
+                    self.total_time_in_secs += 1
+                    self.curr_time_secs += 1
+                    if self.curr_time_secs > 60:
+                        self.curr_time_secs = 0
+                        self.curr_time_minutes += 1
+                        if self.curr_time_minutes > 60:
+                            self.curr_time_minutes = 0
+                            self.curr_time_hours += 1
+                """
+                print("outside")
 
+            """
+            self.time_back_secs = int(binned_time/1000)
+            self.curr_time_secs += self.time_back_secs
+            #self.time_flag = True
+            print(self.curr_time_secs, "secs")
+            print(int(binned_time/1000), "back")
+            if binned_time < temp * 60:
+                self.curr_time_minutes += int((binned_time/1000) * 60)
+                if binned_time < temp * 360:
+                    self.curr_time_hours += int(((binned_time/1000) * 60) * 60)
+            """
         # Formats the time displaying current time/ total time
         # and then sets the text label in the media control panel.
         time_str_formatted = f"Time: {self.curr_time_hours:02d}:{self.curr_time_minutes:02d}:{self.curr_time_secs:02d}" \

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -1,5 +1,6 @@
 import io
 import csv
+import math
 import sys
 
 from datetime import datetime
@@ -86,6 +87,8 @@ class WindowController:
         self.curr_time_secs = 0
         self.curr_time_minutes = 0
         self.curr_time_hours = 0
+        self.time_back_secs = 0
+        self.time_flag = False
         self._media_player.positionChanged.connect(self.get_video_time_total)
 
         self._window.table_panel.add_col_button.clicked.connect(self.add_col_to_encoding_table)
@@ -197,15 +200,31 @@ class WindowController:
         # This gets the current time in seconds.
         temp = self.total_time_in_secs
         current_time = current_time - (1000 * self.total_time_in_secs)
+        #print(self.total_time_in_secs, "seconds")
+        #print(current_time, "ms")
         if current_time > 1000:
             self.total_time_in_secs += 1
             self.curr_time_secs += 1
-        if self.curr_time_secs > 60:
-            self.curr_time_secs = 0
-            self.curr_time_minutes += 1
-        if self.curr_time_minutes > 60:
-            self.curr_time_minutes = 0
-            self.curr_time_hours += 1
+            if self.curr_time_secs > 60:
+                self.curr_time_secs = 0
+                self.curr_time_minutes += 1
+                if self.curr_time_minutes > 60:
+                    self.curr_time_minutes = 0
+                    self.curr_time_hours += 1
+        elif current_time < 0 and self.time_flag is False:
+            #temp = -1000
+            binned_time = current_time - (current_time % -temp)
+            print(binned_time, "bin_in_ms")
+            if binned_time < temp:
+                self.time_back_secs = int(binned_time/1000)
+                self.curr_time_secs += self.time_back_secs
+                self.time_flag = True
+                print(self.curr_time_secs, "secs")
+                print(int(binned_time/1000), "back")
+                """if binned_time < temp * 60:
+                    self.curr_time_minutes += int((binned_time/1000) * 60)
+                    if binned_time < temp * 360:
+                        self.curr_time_hours += int(((binned_time/1000) * 60) * 60)"""
 
         # Formats the time displaying current time/ total time
         # and then sets the text label in the media control panel.

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -174,6 +174,10 @@ class WindowController:
         # Get the total time of the video in milliseconds.
         total_in_ms = self._media_player.duration()
         current_time = self._media_player.position()
+        print(current_time, "before conversion")
+        """
+        move this stuff to an entity, use the current time conversion below
+        """
 
         # This convert to seconds, minutes, hours, and frames
         # and rounds down to the nearest value.
@@ -201,6 +205,7 @@ class WindowController:
         # This gets the current time in seconds.
         temp = self.total_time_in_secs
         current_time = current_time - (1000 * self.total_time_in_secs)
+        print(current_time, "after conversion")
         #print(self.total_time_in_secs, "seconds")
         #print(current_time, "ms")
         if current_time > 1000:
@@ -215,13 +220,13 @@ class WindowController:
         elif current_time < 0:
             binned_time = current_time - (current_time % -temp)
             self.time_back_secs = int(binned_time / 1000)
-            print(self.time_back_secs)
-            print(self.max_time_back)
+            #print(self.time_back_secs)
+            #print(self.max_time_back)
             if self.time_back_secs < self.max_time_back:
                 self.curr_time_secs -= self.max_time_back
                 self.max_time_back = self.time_back_secs
                 self.curr_time_secs += self.max_time_back
-                print("inside")
+                #print("inside")
             else:
                 """
                 if current_time < 1000:
@@ -234,7 +239,7 @@ class WindowController:
                             self.curr_time_minutes = 0
                             self.curr_time_hours += 1
                 """
-                print("outside")
+                #print("outside")
 
             """
             self.time_back_secs = int(binned_time/1000)


### PR DESCRIPTION
Fix time bug error when scrubbing backwards

This patch fixes the error that was occurring when scrubbing backwards.
This prevented an accurate timestamp being displayed if the user scrubbed
back in the video as the timestamp would not decrease. The patch being
implemented should have fixed it.

Testing Steps
  1. Run the application
  2. Load a video
  3. Verify that the timestamp is accurate when it starts
  4. Verify the time is accurate scrubbing backwards in the video
  5. Verify the time is accurate scrubbing forwards in the video

Type: Bug Fix