### PR TITLE
Adds functionality to optional table title field

### DIFF
--- a/Controllers/project_management_controller.py
+++ b/Controllers/project_management_controller.py
@@ -66,8 +66,11 @@ class ProjectManagementController:
         session_name = self.session_creator_page.session_input.text()
         if session_name == "" or not self.is_unique_session_name(session_name):
             return
+        table_title = self.session_creator_page.table_input.text()
+        if table_title == "":
+            table_title = "Table Title"
 
-        self.state_controller.create_new_window(session_name)
+        self.state_controller.create_new_window(session_name, table_title)
         self.session_creator_page.parent().close()
 
     @Slot(SessionOption)

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -49,6 +49,7 @@ class StateController:
         self.global_settings_manager.load_global_settings()
 
         self.window.closing.connect(lambda: self.write_session_slot(session_name))
+        self.window_controller.establish_table_title(table_name)
         self.window.connect_create_session_to_slot(self.open_session_creator_page)
         self.window.connect_load_session_to_slot(self.open_session_management_page)
 
@@ -71,6 +72,7 @@ class StateController:
         Parameters:
             session_id - identifier of session to load
         """
+        
         self.create_new_window(session_id)
         self.session_manager.load_existing_session(session_id)
 

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -147,16 +147,16 @@ class WindowController:
         """
         self._window.table_panel.table.edit_header(section)
 
-    def establish_table_title(self):
+    def establish_table_title(self, table_title):
         """
         Opens an input dialog box to request an initial title for the encoding
         table of the session. Then, sets the initial title to the user-response.
         """
-        text, ok = QInputDialog.getText(self._window, "Encoding Table Title Name",
-                                        "Encoding Table Title:", QLineEdit.Normal, "")
-        if ok and text:
-            self._window.table_panel.title.setText(text)
-            self.resize_to_content()
+        # text, ok = QInputDialog.getText(self._window, "Encoding Table Title Name",
+        #                                 "Encoding Table Title:", QLineEdit.Normal, "")
+        # if ok and text:
+        self._window.table_panel.title.setText(table_title)
+        self.resize_to_content()
 
     @Slot()
     def done_editing(self):


### PR DESCRIPTION
Before this patch, there was a table title input field on the "Create New Session" window that had no functionality. This patch adds functionality so that if a user enters a table title, that title will be displayed above the table when the main application window launches. If a user creates a new session without specifying a table title, the default title will be "Table Title".

Testing steps:
1. Run the application
2. Clear all sessions
3. Create a new session "Session A" and enter "Session A" for the table title as well
4. Check that the table title is "Session A"
5. Close the application
6. Reopen Session A, and check that the table title is still "Session A"
7. Edit the table title to "Session 1"
8. Close the application and reopen Session A, and check that the table title is still "Session 1"
9. Close the application and create a new session "Session B" and enter "Session B" for the table title
10. Check that the table title is "Session B"
11. Close the application and reopen Session A, and make sure the table title is still "Session 1"

Type: New Feature