### PR TITLE
Dev save user settings

### DIFF
--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -20,14 +20,14 @@ class GlobalSettingsManager:
         Add a button definition to the button definition list
         """
         self.global_settings_entity.button_definitions.append(button_definition)
-        self.update_saved_settings()
+        self.save_encoding_button_definitions()
 
     def remove_button_definition(self, button_definition):
         """
         Remove a button definition from the button definition list
         """
         self.global_settings_entity.button_definitions.remove(button_definition)
-        self.update_saved_settings()
+        self.save_encoding_button_definitions()
 
     def get_button_definition(self, button_id):
         """
@@ -38,7 +38,7 @@ class GlobalSettingsManager:
                 return button_definition
         return None
 
-    def update_saved_settings(self):
+    def save_encoding_button_definitions(self):
         """
         Update the global settings
         """
@@ -58,8 +58,8 @@ class GlobalSettingsManager:
             settings.endArray()
         settings.endArray()
 
-        settings.endGroup() # encoding-buttons
-        settings.endGroup() # global-settings
+        settings.endGroup()  # encoding-buttons
+        settings.endGroup()  # global-settings
 
     def load_global_settings(self):
         """
@@ -69,15 +69,17 @@ class GlobalSettingsManager:
 
         settings.beginGroup("global-settings")
 
-        settings.beginGroup("user-settings")  # open user settings
+        settings.beginGroup("user-settings")
 
         # Sets the padding and the max width to global settings entity
-        self.global_settings_entity.table_padding = settings.value("table_padding")
-        self.global_settings_entity.table_maximum_width = settings.value("table_maximum_width")
+        self.global_settings_entity.table_padding = int(settings.value("table_padding"))
+        self.global_settings_entity.table_maximum_width = int(settings.value("table_maximum_width"))
 
         # Sets the cell size with width, index 0, and height, index 1 to global settings entity
-        self.global_settings_entity.table_cell_size.append(settings.value("table_cell_size_width"))
-        self.global_settings_entity.table_cell_size.append(settings.value("table_cell_size_height"))
+        self.global_settings_entity.table_cell_size.append(int(settings.value("table_cell_size_width")))
+        self.global_settings_entity.table_cell_size.append(int(settings.value("table_cell_size_height")))
+
+        settings.endGroup()  # user-settings
 
         settings.beginGroup("encoding-buttons")
 
@@ -95,11 +97,10 @@ class GlobalSettingsManager:
             self.global_settings_entity.button_definitions.append(button_definition)
         settings.endArray()
 
-        settings.endGroup()
-        settings.endGroup()
-        settings.endGroup()
+        settings.endGroup()  # encoding-buttons
+        settings.endGroup()  # global-settings
 
-    def set_to_user_settings(self):
+    def save_user_settings(self):
         """
         Saves the values in the global settings entity to Qsettings
         """
@@ -107,7 +108,7 @@ class GlobalSettingsManager:
 
         settings.beginGroup("global-settings")
 
-        settings.beginGroup("user-settings")  # open user settings
+        settings.beginGroup("user-settings")
 
         # Sets the padding and the max width.
         settings.setValue("table_padding", self.global_settings_entity.table_padding)
@@ -122,28 +123,28 @@ class GlobalSettingsManager:
 
     def set_table_padding(self, table_padding):
         """
-        Setter method to set the cell padding.
+        Setter method to set the cell padding to the global settings entity.
 
         Parameter:
-            String
+            Int representing the padding in each table cell.
         """
         self.global_settings_entity.table_padding = table_padding
 
     def set_table_cell_size(self, table_cell_size):
         """
-        Setter method to set the cell size.
+        Setter method to set the cell size to the global settings entity.
 
         Parameter:
-            List
+            List of ints with index 0 holding the width and index 1 holding the height.
         """
         self.global_settings_entity.table_cell_size = table_cell_size
 
     def set_table_maximum_width(self, table_maximum_width):
         """
-        Setter method to set the cell max width.
+        Setter method to set the cell max width to the global settings entity.
 
         Parameter:
-            Int
+            Int representing the max width of each table cell.
         """
         self.global_settings_entity.table_maximum_width = table_maximum_width
 

--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -65,8 +65,8 @@ class GlobalSettingsManager:
             settings.endArray()
         settings.endArray()
 
-        settings.endGroup() # global-settings
         settings.endGroup() # encoding-buttons
+        settings.endGroup() # global-settings
 
     def load_global_settings(self):
         """
@@ -75,6 +75,17 @@ class GlobalSettingsManager:
         settings = QSettings()
 
         settings.beginGroup("global-settings")
+
+        settings.beginGroup("user-settings")  # open user settings
+
+        # Sets the padding and the max width to global settings entity
+        self.global_settings_entity.table_padding = settings.value("table_padding")
+        self.global_settings_entity.table_maximum_width = settings.value("table_maximum_width")
+
+        # Sets the cell size with width, index 0, and height, index 1 to global settings entity
+        self.global_settings_entity.table_cell_size.append(settings.value("table_cell_size_width"))
+        self.global_settings_entity.table_cell_size.append(settings.value("table_cell_size_height"))
+
         settings.beginGroup("encoding-buttons")
 
         button_definitions_length = settings.beginReadArray("button-definitions")
@@ -94,3 +105,52 @@ class GlobalSettingsManager:
 
         settings.endGroup()
         settings.endGroup()
+        settings.endGroup()
+
+    def set_to_user_settings(self):
+        """
+        Saves the values in the global settings entity to Qsettings
+        """
+        settings = QSettings()
+
+        settings.beginGroup("global-settings")
+
+        settings.beginGroup("user-settings")  # open user settings
+
+        # Sets the padding and the max width.
+        settings.setValue("table_padding", self.global_settings_entity.table_padding)
+        settings.setValue("table_maximum_width", self.global_settings_entity.table_maximum_width)
+
+        # Sets the cell size with width, index 0, and height, index 1.
+        settings.setValue("table_cell_size_width", self.global_settings_entity.table_cell_size[0])
+        settings.setValue("table_cell_size_height", self.global_settings_entity.table_cell_size[1])
+
+        settings.endGroup()
+        settings.endGroup()
+
+    def set_table_padding(self, table_padding):
+        """
+        Setter method to set the cell padding.
+
+        Parameter:
+            String
+        """
+        self.global_settings_entity.table_padding = table_padding
+
+    def set_table_cell_size(self, table_cell_size):
+        """
+        Setter method to set the cell size.
+
+        Parameter:
+            List
+        """
+        self.global_settings_entity.table_cell_size = table_cell_size
+
+    def set_table_maximum_width(self, table_maximum_width):
+        """
+        Setter method to set the cell max width.
+
+        Parameter:
+            Int
+        """
+        self.global_settings_entity.table_maximum_width = table_maximum_width

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -48,6 +48,15 @@ class StateController:
 
         self.global_settings_manager.load_global_settings()
 
+        # After loading the values from QSettings, adjusts the table format.
+        self.window.table_panel.table.set_cell_size(
+            self.global_settings_manager.global_settings_entity.table_cell_size[0],
+            self.global_settings_manager.global_settings_entity.table_cell_size[1])
+        self.window.table_panel.table.set_maximum_width(
+            self.global_settings_manager.global_settings_entity.table_maximum_width)
+        self.window.table_panel.table.set_padding(
+            str(self.global_settings_manager.global_settings_entity.table_padding))
+
         self.window.closing.connect(lambda: self.write_session_slot(session_name))
         self.window.connect_create_session_to_slot(self.open_session_creator_page)
         self.window.connect_load_session_to_slot(self.open_session_management_page)

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -48,7 +48,7 @@ class StateController:
 
         self.global_settings_manager.load_global_settings()
 
-        # After loading the values from QSettings, adjusts the table format.
+        # After loading the values from QSettings, adjusts the table format according to the global user settings.
         self.window.table_panel.table.set_cell_size(
             self.global_settings_manager.global_settings_entity.table_cell_size[0],
             self.global_settings_manager.global_settings_entity.table_cell_size[1])

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -326,8 +326,8 @@ class WindowController:
         table_padding = self._window.table_panel.table.get_padding()
         self.global_settings_manager.set_table_padding(table_padding)
 
-        # Saves the data do QSettings bin call user_settings.
-        self.global_settings_manager.set_to_user_settings()
+        # Saves the data to file.
+        self.global_settings_manager.save_user_settings()
 
     @Slot()
     def play_video(self):

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -320,6 +320,19 @@ class WindowController:
         self.user_settings.connect_padding_to_slot(self.set_padding)
         self.user_settings.exec()
 
+        # Gets each value from the table and passes to global_settings_manager.
+        table_cell_size = self._window.table_panel.table.get_cell_size()
+        self.global_settings_manager.set_table_cell_size(table_cell_size)
+
+        table_maximum_width = self._window.table_panel.table.get_maximum_width()
+        self.global_settings_manager.set_table_maximum_width(table_maximum_width)
+
+        table_padding = self._window.table_panel.table.get_padding()
+        self.global_settings_manager.set_table_padding(table_padding)
+
+        # Saves the data do QSettings bin call user_settings.
+        self.global_settings_manager.set_to_user_settings()
+
     @Slot()
     def play_video(self):
         """ Command a video to change the state to play and pause when clicked. """

--- a/Models/global_settings_entity.py
+++ b/Models/global_settings_entity.py
@@ -7,3 +7,6 @@ class GlobalSettingsEntity:
         Constructor - Creates an instance of GlobalSettingsEntity
         """
         self.button_definitions = []
+        self.table_padding = 0
+        self.table_cell_size = []
+        self.table_maximum_width = 0

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -17,6 +17,9 @@ class EncodingTable(QTableWidget):
         self.setRowCount(10)
         self.setColumnCount(4)
 
+        # Holds the padding in non stylesheet format
+        self.padding = 0
+
         self.horizontalHeader().setStretchLastSection(True)
         self.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Interactive)
         self.horizontalHeader().setDefaultSectionSize(100)
@@ -173,6 +176,36 @@ class EncodingTable(QTableWidget):
         """
         return self.columnCount()
 
+    def get_cell_size(self):
+        """
+        Getter method to get cell size.
+
+        Returns:
+            list
+        """
+        min_width = self.horizontalHeader().minimumSectionSize()
+        min_height = self.verticalHeader().minimumSectionSize()
+        return [min_width, min_height]
+
+    def get_maximum_width(self):
+        """
+        Getter method to get cell max width.
+
+        Returns:
+            int
+        """
+        max_width = self.horizontalHeader().maximumSectionSize()
+        return max_width
+
+    def get_padding(self):
+        """
+        Getter method to get cell padding.
+
+        Returns:
+            int
+        """
+        return self.padding
+
     def get_headers(self):
         """
         Getter method to get table headers.
@@ -224,6 +257,7 @@ class EncodingTable(QTableWidget):
         """
         Changes default padding.
         """
+        self.padding = padding
         self.setStyleSheet("QTableWidget::item { padding: " + padding + "px }")
 
     def set_row_count(self, table_row):

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -181,7 +181,7 @@ class EncodingTable(QTableWidget):
         Getter method to get cell size.
 
         Returns:
-            list
+            List of ints with index 0 holding the width and index 1 holding the height.
         """
         min_width = self.horizontalHeader().minimumSectionSize()
         min_height = self.verticalHeader().minimumSectionSize()
@@ -192,7 +192,7 @@ class EncodingTable(QTableWidget):
         Getter method to get cell max width.
 
         Returns:
-            int
+            Int representing the max width of each table cell.
         """
         max_width = self.horizontalHeader().maximumSectionSize()
         return max_width
@@ -202,7 +202,7 @@ class EncodingTable(QTableWidget):
         Getter method to get cell padding.
 
         Returns:
-            int
+            Int representing the padding in each table cell.
         """
         return self.padding
 


### PR DESCRIPTION
Allows user settings to persist through settings.

This patch allows for the user settings: cell size, cell max width, cell padding
to persist as global settings for the user. This was implemented because we wanted
these settings to persist over all settings. As these settings are global settings they
should persist through all sessions, even when the user makes a new session.

Testing Steps
  1. Run the application
  2. Create a new session called test1
  3. Access the settings panel
  4. Change the settings of cell size, cell max width, and padding 
      so the cell size visually change
  5. Close and reopen test1 and verify they are still there
  6. Close and create a new session call test2 and test3
  7. Open both a verify that the user settings persist in both
       
Type: New Feature