### PR TITLE
Adds tick marks to the scaling and progress bars

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -3,6 +3,7 @@ import csv
 import math
 import sys
 
+import cv2
 from PySide6.QtCore import Slot, QMimeDatabase, QByteArray
 from PySide6.QtGui import QFontMetrics, QKeySequence
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
@@ -41,6 +42,7 @@ class WindowController:
     The WindowController responds to input events from the Window. The Controller
     handles the main logic of the application.
     """
+    DEFAULT_FRAMES_PER_SECOND = 30
 
     def __init__(self, window, global_settings_manager):
         """
@@ -59,6 +61,7 @@ class WindowController:
             self._window.media_panel.video_widget)
         self._media_player.setAudioOutput(
             self._window.media_panel.audio_widget)
+        self.fps = None
 
         self._window.connect_load_video_to_slot(self.open_file_dialog)
         self._window.connect_settings_to_slot(self.open_settings_dialog)
@@ -175,7 +178,9 @@ class WindowController:
         Parameters:
             new_duration - current duration of the video.
         """
-        self._window.media_panel.scrubber_bar.initialize(new_duration)
+        if not self.fps:
+            self.fps = self.DEFAULT_FRAMES_PER_SECOND
+        self._window.media_panel.scrubber_bar.initialize(new_duration, self.fps)
 
     @Slot()
     def get_video_time_total(self):
@@ -275,6 +280,9 @@ class WindowController:
             url = file_dialog.selectedUrls()[0]
             self._media_player.setSource(url)
             self._media_player.play()
+
+            video = cv2.VideoCapture(url.url())
+            self.fps = video.get(cv2.CAP_PROP_FPS)
 
     @Slot()
     def save_to_file(self):

--- a/View/scrubber_bar.py
+++ b/View/scrubber_bar.py
@@ -25,10 +25,14 @@ class ScrubberBar(QWidget):
         self.scaling_bar.setBarMovesAllHandles(True)
         self.scaling_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scaling_bar.setValue((self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1]))
+        self.scaling_bar.setTickInterval(100)
+        self.scaling_bar.setTickPosition(QSlider.TicksBelow)
 
         # This slider will be read-only, represents the progress for the scaling bar.
         self.scaling_progress_view = QSlider(Qt.Orientation.Horizontal)
         self.scaling_progress_view.setEnabled(False)
+        self.scaling_progress_view.setTickInterval(100)
+        self.scaling_progress_view.setTickPosition(QSlider.TicksBelow)
 
         self.progress_bar_view = ProgressBarView()
 


### PR DESCRIPTION
This patch adds tick marks below the scaling and progress bar views of the scalable scrubbing bar. The tick marks are placed below the sliders, and have a default interval of 100. In the future, once the video fps is known, the default value may change accordingly.

Testing Steps:
  1. Run the application
  2. Create or load a session
  3. Load a video
  4. Verify that there are tick marks below all three sliders that make up the scalable scrubbing bar

Type: New Feature