### PR TITLE
Sets the tick interval according to video fps

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -3,6 +3,7 @@ import csv
 import math
 import sys
 
+import cv2
 from PySide6.QtCore import Slot, QMimeDatabase, QByteArray
 from PySide6.QtGui import QFontMetrics, QKeySequence
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
@@ -41,6 +42,7 @@ class WindowController:
     The WindowController responds to input events from the Window. The Controller
     handles the main logic of the application.
     """
+    DEFAULT_FRAMES_PER_SECOND = 30
 
     def __init__(self, window, global_settings_manager):
         """
@@ -59,6 +61,7 @@ class WindowController:
             self._window.media_panel.video_widget)
         self._media_player.setAudioOutput(
             self._window.media_panel.audio_widget)
+        self.fps = None
 
         self._window.connect_load_video_to_slot(self.open_file_dialog)
         self._window.connect_settings_to_slot(self.open_settings_dialog)
@@ -175,7 +178,9 @@ class WindowController:
         Parameters:
             new_duration - current duration of the video.
         """
-        self._window.media_panel.scrubber_bar.initialize(new_duration)
+        if not self.fps:
+            self.fps = self.DEFAULT_FRAMES_PER_SECOND
+        self._window.media_panel.scrubber_bar.initialize(new_duration, self.fps)
 
     @Slot()
     def get_video_time_total(self):
@@ -275,6 +280,9 @@ class WindowController:
             url = file_dialog.selectedUrls()[0]
             self._media_player.setSource(url)
             self._media_player.play()
+
+            video = cv2.VideoCapture(url.url())
+            self.fps = video.get(cv2.CAP_PROP_FPS)
 
     @Slot()
     def save_to_file(self):


### PR DESCRIPTION
This patch adds functionality, with the utilization of the opencv module, to obtain the frames per second of any loaded video. This patch gets the frames per second of the loaded video and sets the tick marks of the scaling bars according to the interval between frames.

Testing Steps:
  1. Add a print statement to the on_video_duration_changed slot in the WindowController class to reveal the frames per second data member once a video is loaded
  2. Run the application
  3. Create or load a session
  4. Load a video file
  5. Verify that the printed frames per second is correct
  6. Verify that the tick mark interval of the scaling and progress bars are set to the frames per millisecond equivalent value
  7. Zoom in, using the scaling bar, past 50% and verify that the tick mark value increment is divided in half.

Integration Steps:
  1. Use pip to install the opencv-python module https://pypi.org/project/opencv-python/

Type: New Feature