### PR TITLE
Edit and Remove Button Definitions from the User Settings Page

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -618,6 +618,9 @@ class WindowController:
             button_definition - An instance of ButtonDefinition
         """
         video_timestamp = self._window.media_panel.media_control_panel.time_stamp.text()
+        split_one = video_timestamp.split("Time: ")
+        split_two = split_one[1].split("/")
+        video_timestamp = split_two[0]
         for row in range(self._window.table_panel.table.rowCount()):
             column = 0
             cell = self._window.table_panel.table.item(row, column)

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -10,7 +10,9 @@ from PySide6.QtWidgets import QFileDialog, QDialog, QStyle, QInputDialog, QLineE
     QMessageBox
 
 from Application.button_manager import ButtonManager
+from View.edit_coding_assistance_button_dialog import EditCodingAssistanceButtonDialog
 from View.load_coding_assistance_button_dialog import LoadCodingAssistanceButtonDialog
+from View.select_edit_button_dialog import SelectEditButtonDialog
 from View.user_settings_dialog import UserSettingsDialog
 from View.add_coding_assistance_button_dialog import AddCodingAssistanceButtonDialog
 from View.delete_coding_assistance_button_dialog import DeleteCodingAssistanceButtonDialog
@@ -469,6 +471,7 @@ class WindowController:
         int_end_time = int(str_end_time) * 1000
         self._window.media_panel.progress_bar.setMaximum(int_end_time)
 
+    @Slot()
     def open_add_coding_assistance_button_dialog(self):
         """
         Open a dialog to create a new Coding Assistance Button
@@ -478,8 +481,11 @@ class WindowController:
             self.open_save_coding_assistance_button_dialog)
         self.add_coding_assistance_button_dialog.connect_load_button_to_slot(
             self.open_load_coding_assistance_button_dialog)
+        self.add_coding_assistance_button_dialog.connect_edit_button_to_slot(
+            self.open_select_edit_button_dialog)
         self.add_coding_assistance_button_dialog.exec()
 
+    @Slot()
     def open_delete_coding_assistance_button_dialog(self):
         """
         Open a dialog to create a new Coding Assistance Button
@@ -488,6 +494,26 @@ class WindowController:
         self.delete_coding_assistance_button_dialog.connect_delete_button_to_slot(self.delete_coding_assistance_button)
         self.delete_coding_assistance_button_dialog.exec()
 
+    @Slot()
+    def open_select_edit_button_dialog(self):
+        """
+        Open a dialog to select a Coding Assistance Button to edit
+        """
+        self.select_edit_button_dialog = SelectEditButtonDialog()
+        self.select_edit_button_dialog.connect_edit_button_to_slot(
+            self.open_edit_coding_assistance_button_dialog)
+        self.select_edit_button_dialog.exec()
+
+    @Slot()
+    def open_edit_coding_assistance_button_dialog(self):
+        """
+        Open a dialog to edit a Coding Assistance Button
+        """
+        self.edit_button_dialog = EditCodingAssistanceButtonDialog(self._window.table_panel.table)
+        self.edit_button_dialog.connect_edit_button_to_slot(self.edit_coding_assistance_button)
+        self.edit_button_dialog.exec()
+
+    @Slot()
     def open_load_coding_assistance_button_dialog(self):
         """
         Open a dialog to load a Coding Assistance Button
@@ -608,6 +634,36 @@ class WindowController:
         self._window.coding_assistance_panel.button_panel.delete_coding_assistance_button(button_id)
         self.button_manager.remove_button_definition(button_id)
         self.button_manager.remove_button_hotkey(button_id)
+
+    @Slot()
+    def edit_coding_assistance_button(self):
+        """
+        Edit a button definition in Global Settings
+        """
+        button_id = self.select_edit_button_dialog.button_name_textbox.text()
+        for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
+            if button_id == button_definition.button_id:
+                button_name = self.edit_button_dialog.button_id_textbox.text()
+                hotkey = self.edit_button_dialog.hotkey_textbox.text()
+
+                data = []
+                for text in self.add_coding_assistance_button_dialog.dynamic_line_edits:
+                    data.append(text.text())
+                hotkeys = self.global_settings_manager.get_button_hotkeys()
+
+                new_button_definition = ButtonDefinitionEntity(button_name, hotkey, data)
+
+                if hotkey in hotkeys:
+                    self.edit_button_dialog.error_label.setText("This hotkey is already being used!")
+                else:
+                    for i in range(len(self.global_settings_manager.global_settings_entity.button_definitions)):
+                        if button_definition == self.global_settings_manager.global_settings_entity.button_definitions[i]:
+                            self.global_settings_manager.global_settings_entity.button_definitions[i] = new_button_definition
+                            self.edit_button_dialog.error_label.setText("")
+                return
+
+        self.edit_button_dialog.error_label.setText("Button Definition to be edited does not exist")
+        return
 
     @Slot(ButtonDefinitionEntity)
     def dynamic_button_click(self, button_definition):

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -518,8 +518,7 @@ class WindowController:
         """
         Open a dialog to load a Coding Assistance Button
         """
-        self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
-            self.global_settings_manager.global_settings_entity.button_definitions)
+        self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(self.button_manager.definition_map)
         self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
             self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.checkboxes))
         self.load_coding_assistance_button_dialog.exec()
@@ -640,30 +639,16 @@ class WindowController:
         """
         Edit a button definition in Global Settings
         """
-        button_id = self.select_edit_button_dialog.button_name_textbox.text()
+        edit_button_id = self.select_edit_button_dialog.button_name_textbox.text()
         for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
-            if button_id == button_definition.button_id:
-                button_name = self.edit_button_dialog.button_id_textbox.text()
-                hotkey = self.edit_button_dialog.hotkey_textbox.text()
-
+            if edit_button_id == button_definition.button_id:
+                button_id = self.edit_button_dialog.button_id_textbox.text()
                 data = []
-                for text in self.add_coding_assistance_button_dialog.dynamic_line_edits:
-                    data.append(text.text())
-                hotkeys = self.global_settings_manager.get_button_hotkeys()
-
-                new_button_definition = ButtonDefinitionEntity(button_name, hotkey, data)
-
-                if hotkey in hotkeys:
-                    self.edit_button_dialog.error_label.setText("This hotkey is already being used!")
-                else:
-                    for i in range(len(self.global_settings_manager.global_settings_entity.button_definitions)):
-                        if button_definition == self.global_settings_manager.global_settings_entity.button_definitions[i]:
-                            self.global_settings_manager.global_settings_entity.button_definitions[i] = new_button_definition
-                            self.edit_button_dialog.error_label.setText("")
-                return
-
-        self.edit_button_dialog.error_label.setText("Button Definition to be edited does not exist")
-        return
+                for line_edit in self.edit_button_dialog.dynamic_line_edits:
+                    data.append(line_edit.text())
+                new_button_definition = ButtonDefinitionEntity(button_id, data)
+                self.global_settings_manager.global_settings_entity.button_definitions.remove(button_definition)
+                self.global_settings_manager.global_settings_entity.button_definitions.append(new_button_definition)
 
     @Slot(ButtonDefinitionEntity)
     def dynamic_button_click(self, button_definition):
@@ -677,15 +662,17 @@ class WindowController:
         split_one = video_timestamp.split("Time: ")
         split_two = split_one[1].split("/")
         video_timestamp = split_two[0]
+        timestamp_text = QTableWidgetItem(video_timestamp)
         for row in range(self._window.table_panel.table.rowCount()):
             column = 0
             cell = self._window.table_panel.table.item(row, column)
             if not cell:
-                timestamp_text = QTableWidgetItem(video_timestamp)
                 self._window.table_panel.table.setItem(row, column, timestamp_text)
                 column = 1
-                while column < self._window.table_panel.table.columnCount():
-                    insert_text = QTableWidgetItem(button_definition.data[column])
+                data = 0
+                while column <= self._window.table_panel.table.columnCount():
+                    insert_text = QTableWidgetItem(button_definition.data[data])
                     self._window.table_panel.table.setItem(row, column, insert_text)
                     column += 1
+                    data += 1
                 return

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -36,7 +36,6 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.create_button = QPushButton("Create Button")
         self.load_button = QPushButton("Load Button")
-        self.edit_button = QPushButton("Edit Button")
 
         dialog_layout.addLayout(apply_text_hbox)
         dialog_layout.addSpacing(50)
@@ -63,7 +62,6 @@ class AddCodingAssistanceButtonDialog(QDialog):
         dialog_layout.addWidget(self.error_label)
         dialog_layout.addWidget(self.create_button)
         dialog_layout.addWidget(self.load_button)
-        dialog_layout.addWidget(self.edit_button)
 
         self.setLayout(dialog_layout)
 
@@ -79,8 +77,3 @@ class AddCodingAssistanceButtonDialog(QDialog):
         """
         self.load_button.clicked.connect(slot)
 
-    def connect_edit_button_to_slot(self, slot):
-        """
-        Connect an edit_button event to a slot function in the controller.
-        """
-        self.edit_button.clicked.connect(slot)

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -36,6 +36,7 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.create_button = QPushButton("Create Button")
         self.load_button = QPushButton("Load Button")
+        self.edit_button = QPushButton("Edit Button")
 
         dialog_layout.addLayout(apply_text_hbox)
         dialog_layout.addSpacing(50)
@@ -62,6 +63,7 @@ class AddCodingAssistanceButtonDialog(QDialog):
         dialog_layout.addWidget(self.error_label)
         dialog_layout.addWidget(self.create_button)
         dialog_layout.addWidget(self.load_button)
+        dialog_layout.addWidget(self.edit_button)
 
         self.setLayout(dialog_layout)
 
@@ -76,3 +78,9 @@ class AddCodingAssistanceButtonDialog(QDialog):
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connect an edit_button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -36,6 +36,7 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.create_button = QPushButton("Create Button")
         self.load_button = QPushButton("Load Button")
+        self.edit_button = QPushButton("Edit Button")
 
         dialog_layout.addLayout(apply_text_hbox)
         dialog_layout.addSpacing(50)
@@ -59,6 +60,7 @@ class AddCodingAssistanceButtonDialog(QDialog):
         dialog_layout.addWidget(self.error_label)
         dialog_layout.addWidget(self.create_button)
         dialog_layout.addWidget(self.load_button)
+        dialog_layout.addWidget(self.edit_button)
 
         self.setLayout(dialog_layout)
 
@@ -73,3 +75,9 @@ class AddCodingAssistanceButtonDialog(QDialog):
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connect an edit_button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -44,8 +44,9 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.dynamic_line_edits = []
         headers = [self.table.horizontalHeaderItem(c) for c in range(self.table.columnCount())]
-        labels = [x.text() for x in headers]
-        for i in range(len(labels)):
+        labels = [x.text() for x in headers if x]
+        i = 1
+        while i in range(len(labels)):
             dynamic_input_hbox = QHBoxLayout()
             dynamic_input_label = QLabel(labels[i])
             dynamic_input_field = QLineEdit()
@@ -55,6 +56,8 @@ class AddCodingAssistanceButtonDialog(QDialog):
             dynamic_input_hbox.addWidget(dynamic_input_field)
             dialog_layout.addLayout(dynamic_input_hbox)
             dialog_layout.addSpacing(50)
+
+            i += 1
 
         dialog_layout.addWidget(self.error_label)
         dialog_layout.addWidget(self.create_button)

--- a/View/button_panel.py
+++ b/View/button_panel.py
@@ -33,11 +33,6 @@ class ButtonPanel(QWidget):
             QSizePolicy.Preferred,
             QSizePolicy.Expanding)
 
-        self.add_delete_layout.addWidget(self.add_button)
-        self.add_delete_layout.addWidget(self.delete_button)
-
-        add_delete_container.setLayout(self.add_delete_layout)
-
         # Add css styling to the container to give it a background color.
         button_container.setProperty("class", "button-container")
         add_delete_container.setProperty("class", "add_delete_container")
@@ -58,11 +53,6 @@ class ButtonPanel(QWidget):
         self.grid_layout = GridLayout(self.parent(), 3, 3)
         grid_container.setLayout(self.grid_layout)
         grid_container.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
-        self.add_button = QPushButton("+")
-        self.add_button.setSizePolicy(
-            QSizePolicy.Preferred,
-            QSizePolicy.Expanding)
 
         self.horizontal_layout.addWidget(self.add_button)
         self.horizontal_layout.addWidget(self.delete_button)
@@ -85,6 +75,12 @@ class ButtonPanel(QWidget):
         Connects a delete_button event to a slot function in the controller.
         """
         self.delete_button.clicked.connect(slot)
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connects an edit_button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)
 
     def create_coding_assistance_button(self, button):
         """

--- a/View/edit_coding_assistance_button_dialog.py
+++ b/View/edit_coding_assistance_button_dialog.py
@@ -25,19 +25,13 @@ class EditCodingAssistanceButtonDialog(QDialog):
         button_id_hbox.addWidget(button_id_label)
         button_id_hbox.addWidget(self.button_id_textbox)
 
-        hotkey_hbox = QHBoxLayout()
-        hotkey_label = QLabel("Hotkey: ")
-        self.hotkey_textbox = QLineEdit()
-        hotkey_hbox.addWidget(hotkey_label)
-        hotkey_hbox.addWidget(self.hotkey_textbox)
-
         dialog_layout.addLayout(button_id_hbox)
-        dialog_layout.addLayout(hotkey_hbox)
 
         self.dynamic_line_edits = []
         headers = [self.table.horizontalHeaderItem(c) for c in range(self.table.columnCount())]
-        labels = [x.text() for x in headers]
-        for i in range(len(labels)):
+        labels = [x.text() for x in headers if x]
+        i = 1
+        while i in range(len(labels)):
             dynamic_input_hbox = QHBoxLayout()
             dynamic_input_label = QLabel(labels[i])
             dynamic_input_field = QLineEdit()
@@ -47,6 +41,8 @@ class EditCodingAssistanceButtonDialog(QDialog):
             dynamic_input_hbox.addWidget(dynamic_input_field)
             dialog_layout.addLayout(dynamic_input_hbox)
             dialog_layout.addSpacing(50)
+
+            i += 1
 
         self.edit_button = QPushButton("Edit")
         dialog_layout.addWidget(self.edit_button)

--- a/View/edit_coding_assistance_button_dialog.py
+++ b/View/edit_coding_assistance_button_dialog.py
@@ -1,0 +1,63 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QLineEdit, QPushButton
+
+from Models.button_definition_entity import ButtonDefinitionEntity
+
+
+class EditCodingAssistanceButtonDialog(QDialog):
+    """
+    A Dialog to edit a button definition
+    """
+
+    def __init__(self, table):
+        """
+        Constructor: Initializes the layout of the Edit Coding Assistance Button Dialog
+        """
+
+        super().__init__()
+
+        dialog_layout = QVBoxLayout()
+
+        self.table = table
+
+        button_id_hbox = QHBoxLayout()
+        button_id_label = QLabel("Name: ")
+        self.button_id_textbox = QLineEdit()
+        button_id_hbox.addWidget(button_id_label)
+        button_id_hbox.addWidget(self.button_id_textbox)
+
+        hotkey_hbox = QHBoxLayout()
+        hotkey_label = QLabel("Hotkey: ")
+        self.hotkey_textbox = QLineEdit()
+        hotkey_hbox.addWidget(hotkey_label)
+        hotkey_hbox.addWidget(self.hotkey_textbox)
+
+        dialog_layout.addLayout(button_id_hbox)
+        dialog_layout.addLayout(hotkey_hbox)
+
+        self.dynamic_line_edits = []
+        headers = [self.table.horizontalHeaderItem(c) for c in range(self.table.columnCount())]
+        labels = [x.text() for x in headers]
+        for i in range(len(labels)):
+            dynamic_input_hbox = QHBoxLayout()
+            dynamic_input_label = QLabel(labels[i])
+            dynamic_input_field = QLineEdit()
+            self.dynamic_line_edits.append(dynamic_input_field)
+
+            dynamic_input_hbox.addWidget(dynamic_input_label)
+            dynamic_input_hbox.addWidget(dynamic_input_field)
+            dialog_layout.addLayout(dynamic_input_hbox)
+            dialog_layout.addSpacing(50)
+
+        self.edit_button = QPushButton("Edit")
+        dialog_layout.addWidget(self.edit_button)
+
+        self.error_label = QLabel()
+        dialog_layout.addWidget(self.error_label)
+
+        self.setLayout(dialog_layout)
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connect an edit_button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)

--- a/View/edit_coding_assistance_button_dialog.py
+++ b/View/edit_coding_assistance_button_dialog.py
@@ -26,6 +26,7 @@ class EditCodingAssistanceButtonDialog(QDialog):
         button_id_hbox.addWidget(self.button_id_textbox)
 
         dialog_layout.addLayout(button_id_hbox)
+        dialog_layout.addSpacing(50)
 
         self.dynamic_line_edits = []
         headers = [self.table.horizontalHeaderItem(c) for c in range(self.table.columnCount())]

--- a/View/remove_button_definition_dialog.py
+++ b/View/remove_button_definition_dialog.py
@@ -1,0 +1,43 @@
+from PySide6.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QPushButton
+
+
+class RemoveButtonDefinitionDialog(QDialog):
+    """
+    A dialog to remove or clear button definitions
+    """
+
+    def __init__(self):
+        """
+        Constructor: Initializes the layout of the Remove Button Definition Dialog
+        """
+
+        super().__init__()
+
+        dialog_layout = QVBoxLayout()
+
+        remove_definition_hbox = QHBoxLayout()
+        remove_definition_label = QLabel("Name of button definition to remove: ")
+        self.remove_definition_text = QLineEdit()
+        remove_definition_hbox.addWidget(remove_definition_label)
+        remove_definition_hbox.addWidget(self.remove_definition_text)
+        self.remove_definition_button = QPushButton("Remove Button Definition")
+        self.clear_all_button = QPushButton("Clear all Button Definitions")
+
+        dialog_layout.addLayout(remove_definition_hbox)
+        dialog_layout.addWidget(self.remove_definition_button)
+        dialog_layout.addSpacing(10)
+        dialog_layout.addWidget(self.clear_all_button)
+
+        self.setLayout(dialog_layout)
+
+    def connect_remove_button_to_slot(self, slot):
+        """
+        Connect a remove button event to slot
+        """
+        self.remove_definition_button.clicked.connect(slot)
+
+    def connect_clear_button_to_slot(self, slot):
+        """
+        Connect a clear all button event to slot
+        """
+        self.clear_all_button.clicked.connect(slot)

--- a/View/select_edit_button_dialog.py
+++ b/View/select_edit_button_dialog.py
@@ -1,0 +1,36 @@
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QPushButton
+
+
+class SelectEditButtonDialog(QDialog):
+    """
+    A Dialog to select a button definition to be edited
+    """
+
+    def __init__(self):
+        """
+        Constructor: Initializes the layout of the Select Edit Button dialog
+        """
+
+        super().__init__()
+
+        dialog_layout = QVBoxLayout()
+
+        button_name_hbox = QHBoxLayout()
+        button_name_label = QLabel("Name of button to edit: ")
+        self.button_name_textbox = QLineEdit()
+        button_name_hbox.addWidget(button_name_label)
+        button_name_hbox.addWidget(self.button_name_textbox)
+
+        self.edit_button = QPushButton("Edit")
+
+        dialog_layout.addLayout(button_name_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addWidget(self.edit_button)
+
+        self.setLayout(dialog_layout)
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connect a edit_button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -1,9 +1,9 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton, QLineEdit
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton, QLineEdit, QScrollArea, QWidget
 
 
 class UserSettingsDialog(QDialog):
   
-    def __init__(self):
+    def __init__(self, button_definitions):
         """
         Constructor: Initializes the layout of the settings dialog
         """
@@ -12,13 +12,30 @@ class UserSettingsDialog(QDialog):
         # Creates a vertical layout for the dialog box.
         dialog_layout = QVBoxLayout()
 
-        # Creates horizontal layouts to group common widgets in the dialog.
+        # Initializes button definition settings widgets and inserts them in the dialog
+        dialog_layout.addWidget(QLabel("Encoding Button Definitions"))
+        dialog_layout.addSpacing(5)
+        for button_definition in button_definitions:
+            dialog_layout.addWidget(QLabel("Button: " + button_definition.button_id))
+            for data_index, data in enumerate(button_definition.data):
+                column_number = data_index + 1
+                dialog_layout.addWidget(QLabel("Column " + str(column_number) + " Data: " + data))
+            dialog_layout.addSpacing(10)
+        edit_remove_button_hbox = QHBoxLayout()
+        self.edit_button = QPushButton("Edit Definition")
+        self.remove_button = QPushButton("Remove Definition")
+        edit_remove_button_hbox.addWidget(self.edit_button)
+        edit_remove_button_hbox.addWidget(self.remove_button)
+        dialog_layout.addLayout(edit_remove_button_hbox)
+        dialog_layout.addSpacing(20)
+
+        # Creates horizontal layouts to group common encoding table settings widgets in the dialog.
         minimum_size_hbox = QHBoxLayout()
         maximum_width_hbox = QHBoxLayout()
         padding_hbox = QHBoxLayout()
 
-        # Initializes the widgets of the dialog.
-        encoding_table_label = QLabel("Encoding Table Settings:")
+        # Initializes encoding table settings widgets
+        encoding_table_label = QLabel("Encoding Table Settings")
         minimum_size_label = QLabel("Set minimum cell width and height")
         self.minimum_size_width_box = QLineEdit()
         self.minimum_size_height_box = QLineEdit()
@@ -41,20 +58,41 @@ class UserSettingsDialog(QDialog):
 
         # Adds a title for the encoding table settings to the dialog.
         dialog_layout.addWidget(encoding_table_label)
+        dialog_layout.addSpacing(5)
 
         # Adds all the widgets to the main layout.
-        dialog_layout.addSpacing(50)
         dialog_layout.addWidget(minimum_size_label)
         dialog_layout.addLayout(minimum_size_hbox)
-        dialog_layout.addSpacing(50)
+        dialog_layout.addSpacing(10)
         dialog_layout.addWidget(maximum_width_label)
         dialog_layout.addLayout(maximum_width_hbox)
-        dialog_layout.addSpacing(50)
+        dialog_layout.addSpacing(10)
         dialog_layout.addWidget(padding_label)
         dialog_layout.addLayout(padding_hbox)
 
-        # Sets the layout of the dialog.
-        self.setLayout(dialog_layout)
+        # Sets the layout of the dialog using a QScrollArea.
+        scroll_area = QScrollArea(self)
+        scroll_area.setWidgetResizable(True)
+        scroll_area_widget = QWidget()
+        scroll_area.setWidget(scroll_area_widget)
+        scroll_area_layout = QVBoxLayout(scroll_area_widget)
+        scroll_area_layout.addLayout(dialog_layout)
+        self.setLayout(QVBoxLayout(self))
+        self.layout().addWidget(scroll_area)
+        scroll_area_widget.adjustSize()
+        scroll_area_widget.setMinimumHeight(scroll_area_widget.sizeHint().height())
+
+    def connect_edit_button_to_slot(self, slot):
+        """
+        Connects an edit button event to a slot function in the controller.
+        """
+        self.edit_button.clicked.connect(slot)
+
+    def connect_remove_button_to_slot(self, slot):
+        """
+        Connects a remove button event to a slot function in the controller.
+        """
+        self.remove_button.clicked.connect(slot)
 
     def connect_cell_size_to_slot(self, slot):
         """

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import sys
 
-from PySide6.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication, QSettings
 from PySide6.QtWidgets import QApplication
 
 from Controllers.state_controller import StateController


### PR DESCRIPTION
This patch moves the ability to edit global button definitions from the button panel to the user settings page. This patch also adds functionality to be able to remove global button definitions completely. The user can choose to delete one button definition or all button definitions. 

Testing Steps: 

  1. Create a new session
  2. Click "+" and add a button to the button panel using whatever data you choose
  3. Click "Yes" when prompted to save the button definition
  4. Repeat steps 2 and 3 twice
  5. Close out of the button creation dialog and click "Settings"
  6. Open the Settings dialog
  7. Ensure the button definitions have populated in the dialog
  8. Click "Edit Definition"
  9. Choose the name of the first button in the list and click "Edit"
  10. Insert new data and click "Edit"
  11. Close out of the dialogs until back to the main page
  12. Open the Settings dialog
  13. Ensure the edited button definition has populated at the end of the list according to the data inputted
  14. Click "Remove Definition"
  15. Choose the name of the edited button definition and click "Remove Button Definition"
  16. Close out of the dialogs until back to the main page
  17. Open the settings dialog
  18. Ensure the button definition was removed from the list
  19. Click "Remove Definition"
  20. Click "Clear all Button Definitions" and click "Yes" when prompted
  21. Close out of the dialogs until back to the main page
  22. Open the settings dialog
  23. Ensure all button definitions were removed from the list

Type: New Feature