### PR TITLE
Add a Hotkey While Loading a Single Button

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -495,7 +495,7 @@ class WindowController:
         self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
             self.global_settings_manager.global_settings_entity.button_definitions)
         self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
-            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.checkboxes))
+            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons))
         self.load_coding_assistance_button_dialog.exec()
 
     @Slot()
@@ -577,27 +577,26 @@ class WindowController:
         self.button_manager.add_button_hotkey(button_name, hotkey)
 
     @Slot()
-    def load_coding_assistance_button(self, checkboxes):
+    def load_coding_assistance_button(self, radio_buttons):
         """
         Load selected buttons to the Coding Assistance Panel
 
         Parameters:
-            checkboxes - A list of checkboxes created in the Load Button Dialog
+            radio_buttons - A list of radio buttons created in the Load Button Dialog
         """
-        selected_button_definitions = []
-        for i, checkbox in enumerate(checkboxes):
-            if checkbox.isChecked():
-                selected_button_definitions.append(
-                    self.global_settings_manager.global_settings_entity.button_definitions[i])
-        for button_definition in selected_button_definitions:
-            button_id = button_definition.button_id
-            new_button = QPushButton(button_id)
-            self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(new_button)
-            new_button.clicked.connect(
-                ProjectManagementController.make_lambda(self.dynamic_button_click, button_definition))
+        hotkey = self.load_coding_assistance_button_dialog.hotkey_textfield.text()
+        for i, radio_button in enumerate(radio_buttons):
+            if radio_button.isChecked():
+                button_definition = self.global_settings_manager.global_settings_entity.button_definitions[i]
+        button_id = button_definition.button_id
+        new_button = QPushButton(button_id)
+        new_button.setShortcut(QKeySequence(hotkey))
+        self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(new_button)
+        new_button.clicked.connect(
+            ProjectManagementController.make_lambda(self.dynamic_button_click, button_definition))
 
-            self.button_manager.add_button_definition(button_id, button_definition)
-            self.button_manager.add_button_hotkey(button_id, "Placeholder")
+        self.button_manager.add_button_definition(button_id, button_definition)
+        self.button_manager.add_button_hotkey(button_id, hotkey)
 
     @Slot()
     def delete_coding_assistance_button(self):

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -584,6 +584,8 @@ class WindowController:
         Parameters:
             radio_buttons - A list of radio buttons created in the Load Button Dialog
         """
+        hotkeys = self.button_manager.get_hotkeys()
+
         hotkey = self.load_coding_assistance_button_dialog.hotkey_textfield.text()
         for i, radio_button in enumerate(radio_buttons):
             if radio_button.isChecked():
@@ -591,12 +593,24 @@ class WindowController:
         button_id = button_definition.button_id
         new_button = QPushButton(button_id)
         new_button.setShortcut(QKeySequence(hotkey))
-        self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(new_button)
-        new_button.clicked.connect(
-            ProjectManagementController.make_lambda(self.dynamic_button_click, button_definition))
 
-        self.button_manager.add_button_definition(button_id, button_definition)
-        self.button_manager.add_button_hotkey(button_id, hotkey)
+        if not hotkeys:
+            self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(new_button)
+            new_button.clicked.connect(
+                ProjectManagementController.make_lambda(self.dynamic_button_click, button_definition))
+
+            self.button_manager.add_button_definition(button_id, button_definition)
+            self.button_manager.add_button_hotkey(button_id, hotkey)
+        else:
+            if hotkey in hotkeys:
+                self.load_coding_assistance_button_dialog.error_label.setText("This hotkey is already being used!")
+            else:
+                self._window.coding_assistance_panel.button_panel.create_coding_assistance_button(new_button)
+                new_button.clicked.connect(
+                    ProjectManagementController.make_lambda(self.dynamic_button_click, button_definition))
+
+                self.button_manager.add_button_definition(button_id, button_definition)
+                self.button_manager.add_button_hotkey(button_id, hotkey)
 
     @Slot()
     def delete_coding_assistance_button(self):

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -1,6 +1,4 @@
-from PySide6.QtWidgets import QDialog, QCheckBox, QVBoxLayout, QPushButton
-
-from Models.button_definition_entity import ButtonDefinitionEntity
+from PySide6.QtWidgets import QDialog, QCheckBox, QVBoxLayout, QPushButton, QHBoxLayout, QLabel, QLineEdit, QRadioButton
 
 
 class LoadCodingAssistanceButtonDialog(QDialog):
@@ -12,15 +10,22 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         super().__init__()
 
         dialog_layout = QVBoxLayout()
-        self.checkboxes = []
+        self.radio_buttons = []
 
         for button_definition in button_definitions:
-            checkbox = QCheckBox("Button Name: " + button_definition.button_id)
-            self.checkboxes.append(checkbox)
-            dialog_layout.addWidget(checkbox)
+            radio_button = QRadioButton("Button Name: " + button_definition.button_id)
+            self.radio_buttons.append(radio_button)
+            dialog_layout.addWidget(radio_button)
 
-        self.load_button = QPushButton("Load Buttons Selected")
+        self.load_button = QPushButton("Load Button")
 
+        hotkey_hbox = QHBoxLayout()
+        hotkey_label = QLabel("Assign a hotkey to this button")
+        self.hotkey_textfield = QLineEdit()
+        hotkey_hbox.addWidget(hotkey_label)
+        hotkey_hbox.addWidget(self.hotkey_textfield)
+
+        dialog_layout.addLayout(hotkey_hbox)
         dialog_layout.addWidget(self.load_button)
         self.setLayout(dialog_layout)
 

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -1,6 +1,4 @@
-from PySide6.QtWidgets import QDialog, QCheckBox, QVBoxLayout, QPushButton
-
-from Models.button_definition_entity import ButtonDefinitionEntity
+from PySide6.QtWidgets import QDialog, QCheckBox, QVBoxLayout, QPushButton, QHBoxLayout, QLabel, QLineEdit, QRadioButton
 
 
 class LoadCodingAssistanceButtonDialog(QDialog):
@@ -12,16 +10,23 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         super().__init__()
 
         dialog_layout = QVBoxLayout()
-        self.checkboxes = []
+        self.radio_buttons = []
 
         for button_definition in button_definitions:
-            checkbox = QCheckBox("Button Name: " + button_definition.button_id)
-            self.checkboxes.append(checkbox)
-            dialog_layout.addWidget(checkbox)
+            radio_button = QRadioButton("Button Name: " + button_definition.button_id)
+            self.radio_buttons.append(radio_button)
+            dialog_layout.addWidget(radio_button)
 
         self.load_button = QPushButton("Load Buttons Selected")
 
+        hotkey_hbox = QHBoxLayout()
+        hotkey_label = QLabel("Assign a hotkey to this button")
+        self.hotkey_textfield = QLineEdit()
+        hotkey_hbox.addWidget(hotkey_label)
+        hotkey_hbox.addWidget(self.hotkey_textfield)
+
         dialog_layout.addWidget(self.load_button)
+        dialog_layout.addLayout(hotkey_hbox)
         self.setLayout(dialog_layout)
 
     def connect_load_button_to_slot(self, slot):

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -25,7 +25,10 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         hotkey_hbox.addWidget(hotkey_label)
         hotkey_hbox.addWidget(self.hotkey_textfield)
 
+        self.error_label = QLabel()
+
         dialog_layout.addLayout(hotkey_hbox)
+        dialog_layout.addWidget(self.error_label)
         dialog_layout.addWidget(self.load_button)
         self.setLayout(dialog_layout)
 


### PR DESCRIPTION
This patch changes the UI of the load coding assistance button dialog to ensure a user can only load a single button at a time and allow the user to assign a new hotkey to the button loaded. 

Testing Steps:
  1. Create a new session
  2. Load a video file
  3. Click "+" then create and save a new button with hotkey "a" assigned
  4. Close the dialog and ensure the hotkey activates the button created
  5. Click "+" then create and save a new button with no hotkey
  6. Click "Load Button"
  7. Ensure that you can only select one of the two buttons in the list
  8. Select the first button and assign hotkey "b"
  9. Click "Load Button" and close the dialogs until back to the main panel.
  10. Ensure that the button loaded has the same name as the first and that hotkey "a" activates the first button and hotkey "b" activates the second button

Type: Bug Fix