### PR TITLE
Adds button to restore default user settings

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -319,6 +319,7 @@ class WindowController:
         self.user_settings.connect_cell_size_to_slot(self.set_cell_size)
         self.user_settings.connect_maximum_size_to_slot(self.set_maximum_width)
         self.user_settings.connect_padding_to_slot(self.set_padding)
+        self.user_settings.connect_restore_default_user_settings_to_slot(self.set_default_user_settings)
         self.user_settings.exec()
 
         # Gets each value from the table and passes to global_settings_manager.
@@ -398,6 +399,16 @@ class WindowController:
             self._window.table_panel.table.set_cell_size(width, height)
         except ValueError:
             pass
+
+    @Slot()
+    def set_default_user_settings(self):
+        """
+        Takes input from the settings dialog and restores the cell size, cell max width, and cell padding to default
+        values in the encoding table.
+        """
+        self._window.table_panel.table.set_padding("0")
+        self._window.table_panel.table.horizontalHeader().setDefaultSectionSize(100)
+        self._window.table_panel.table.verticalHeader().setDefaultSectionSize(70)
 
     @Slot()
     def set_maximum_width(self):

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -29,6 +29,7 @@ class UserSettingsDialog(QDialog):
         padding_label = QLabel("Set cell padding")
         self.padding_text_box = QLineEdit()
         self.padding_button = QPushButton("Set Padding")
+        self.restore_default_user_settings_button = QPushButton("Restore Default Settings")
 
         # Adds the widgets to the internal layouts.
         minimum_size_hbox.addWidget(self.minimum_size_width_box)
@@ -52,6 +53,8 @@ class UserSettingsDialog(QDialog):
         dialog_layout.addSpacing(50)
         dialog_layout.addWidget(padding_label)
         dialog_layout.addLayout(padding_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addWidget(self.restore_default_user_settings_button)
 
         # Sets the layout of the dialog.
         self.setLayout(dialog_layout)
@@ -73,4 +76,9 @@ class UserSettingsDialog(QDialog):
         Connects a padding_button event to a slot function in the controller.
         """
         self.padding_button.clicked.connect(slot)
-    
+
+    def connect_restore_default_user_settings_to_slot(self, slot):
+        """
+        Connect a restore_default_user_settings_button event to a slot function in the controller
+        """
+        self.restore_default_user_settings_button.clicked.connect(slot)


### PR DESCRIPTION
Adds button to restore default user settings

Changes made within this patch was adding a button inside the user settings
window to restore the default values for the user settings. This was done in 
order to give the user easy access to reset the format of the Encoding Table.
Our team found that this was a better solution as the user would not know the
default values for the cells within the Encoding Table. 

Testing Steps
  1. Run the program
  2. Open user settings
  3. Change the values inside user settings (padding, min and max width, and min height)
  4. Verify the table has updated
  5. Re-open user settings
  6. Click the "Restore Default Settings" button
  7. Verify the table was changed
  8. Close the session
  9. Re-open the session and verify changes persist

Type: New Feature