### PR TITLE
Adds table font size to user settings

### DIFF
--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -80,8 +80,7 @@ class GlobalSettingsManager:
         self.global_settings_entity.table_cell_size.append(int(settings.value("table_cell_size_height")))
 
         # Sets the font size to global settings entity.
-        print(settings.value(("table_font_size")))
-        # self.global_settings_entity.table_font_size = int(settings.value("table_font_size"))
+        self.global_settings_entity.table_font_size = int(settings.value("table_font_size"))
 
         settings.endGroup()  # user-settings
 

--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -79,6 +79,10 @@ class GlobalSettingsManager:
         self.global_settings_entity.table_cell_size.append(int(settings.value("table_cell_size_width")))
         self.global_settings_entity.table_cell_size.append(int(settings.value("table_cell_size_height")))
 
+        # Sets the font size to global settings entity.
+        print(settings.value(("table_font_size")))
+        # self.global_settings_entity.table_font_size = int(settings.value("table_font_size"))
+
         settings.endGroup()  # user-settings
 
         settings.beginGroup("encoding-buttons")
@@ -118,6 +122,9 @@ class GlobalSettingsManager:
         settings.setValue("table_cell_size_width", self.global_settings_entity.table_cell_size[0])
         settings.setValue("table_cell_size_height", self.global_settings_entity.table_cell_size[1])
 
+        # Sets the table font size.
+        settings.setValue("table_font_size", self.global_settings_entity.table_font_size)
+
         settings.endGroup()
         settings.endGroup()
 
@@ -147,4 +154,13 @@ class GlobalSettingsManager:
             Int representing the max width of each table cell.
         """
         self.global_settings_entity.table_maximum_width = table_maximum_width
+
+    def set_table_font_size(self, table_font_size):
+        """
+        Setter method to set the table font size to the global settings entity.
+
+        Parameter:
+            Int representing the table font size.
+        """
+        self.global_settings_entity.table_font_size = table_font_size
 

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -56,6 +56,8 @@ class StateController:
             self.global_settings_manager.global_settings_entity.table_maximum_width)
         self.window.table_panel.table.set_padding(
             str(self.global_settings_manager.global_settings_entity.table_padding))
+        self.window.table_panel.table.change_font(
+            self.global_settings_manager.global_settings_entity.table_font_size)
 
         self.window.closing.connect(lambda: self.write_session_slot(session_name))
         self.window.connect_create_session_to_slot(self.open_session_creator_page)

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -63,8 +63,8 @@ class WindowController:
         self._window.connect_load_video_to_slot(self.open_file_dialog)
         self._window.connect_settings_to_slot(self.open_settings_dialog)
 
-        self._window.table_panel.change_font_dropDown.activated.connect(
-            self.change_font_of_encoding_table)
+        """self._window.table_panel.change_font_dropDown.activated.connect(
+            self.change_font_of_encoding_table)"""
 
         self._window.table_panel.table.horizontalHeader(
         ).sectionDoubleClicked.connect(self.edit_header)
@@ -331,6 +331,9 @@ class WindowController:
 
         table_padding = self._window.table_panel.table.get_padding()
         self.global_settings_manager.set_table_padding(table_padding)
+
+        table_font_size = self._window.table_panel.table.get_table_font_size()
+        self.global_settings_manager.set_table_font_size(table_font_size)
 
         # Saves the data to file.
         self.global_settings_manager.save_user_settings()

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -137,7 +137,7 @@ class WindowController:
         Command table cells font to update to selected font size.
         """
         selected_font = int(
-            self._window.table_panel.change_font_dropDown.currentText())
+            self.user_settings.change_font_dropDown.currentText())
         self._window.table_panel.table.change_font(selected_font)
 
     @Slot()
@@ -319,6 +319,7 @@ class WindowController:
         self.user_settings.connect_cell_size_to_slot(self.set_cell_size)
         self.user_settings.connect_maximum_size_to_slot(self.set_maximum_width)
         self.user_settings.connect_padding_to_slot(self.set_padding)
+        self.user_settings.connect_font_to_slot(self.change_font_of_encoding_table)
         self.user_settings.exec()
 
         # Gets each value from the table and passes to global_settings_manager.

--- a/Models/global_settings_entity.py
+++ b/Models/global_settings_entity.py
@@ -10,3 +10,4 @@ class GlobalSettingsEntity:
         self.table_padding = 0
         self.table_cell_size = []
         self.table_maximum_width = 0
+        self.table_font_size = 0

--- a/Models/global_settings_entity.py
+++ b/Models/global_settings_entity.py
@@ -10,4 +10,4 @@ class GlobalSettingsEntity:
         self.table_padding = 0
         self.table_cell_size = []
         self.table_maximum_width = 0
-        self.table_font_size = 0
+        self.table_font_size = 1

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -245,10 +245,10 @@ class EncodingTable(QTableWidget):
         Getter method to get table font size.
 
         Returns:
-            Int representing the table font sizw.
+            Int representing the table font size.
         """
-        value = self.font()
-        return value.pointSize()
+        table_font_size = self.font()
+        return table_font_size.pointSize()
 
     def set_cell_size(self, width, height):
         """

--- a/View/encoding_table.py
+++ b/View/encoding_table.py
@@ -240,6 +240,16 @@ class EncodingTable(QTableWidget):
             row_data.append(col_data)
         return row_data
 
+    def get_table_font_size(self):
+        """
+        Getter method to get table font size.
+
+        Returns:
+            Int representing the table font sizw.
+        """
+        value = self.font()
+        return value.pointSize()
+
     def set_cell_size(self, width, height):
         """
         Changes default cell width.

--- a/View/table_panel.py
+++ b/View/table_panel.py
@@ -31,19 +31,19 @@ class TablePanel(QWidget):
             QSizePolicy.Expanding)
 
         """Creates font changing label and dropdown"""
-        font_options = ["8", "9", "10", "11", "12", "14", "16",
+        """font_options = ["8", "9", "10", "11", "12", "14", "16",
                         "18", "20", "22", "24", "26", "28", "36", "48", "72"]
         self.change_font_label = QLabel("Change font: ")
         self.change_font_dropDown = QComboBox()
-        self.change_font_dropDown.addItems(font_options)
+        self.change_font_dropDown.addItems(font_options)"""
 
         grid_layout = QGridLayout()
         grid_layout.addWidget(self.title, 0, 0, QtCore.Qt.AlignCenter)
         grid_layout.addWidget(self.table, 1, 0)
         grid_layout.addWidget(self.add_col_button, 1, 1, alignment=Qt.AlignCenter)
         grid_layout.addWidget(self.add_row_button, 1, 1, alignment=Qt.AlignBottom)
-        grid_layout.addWidget(self.change_font_label, 1, 1, alignment=Qt.AlignTop)
-        grid_layout.addWidget(self.change_font_dropDown, 1, 2, alignment=Qt.AlignTop|Qt.AlignLeft)
+        #grid_layout.addWidget(self.change_font_label, 1, 1, alignment=Qt.AlignTop)
+        #grid_layout.addWidget(self.change_font_dropDown, 1, 2, alignment=Qt.AlignTop|Qt.AlignLeft)
         grid_layout.addWidget(self.delete_col_button, 1, 2, alignment=Qt.AlignCenter)
         grid_layout.addWidget(self.delete_row_button, 1, 2, alignment=Qt.AlignBottom)
         self.setLayout(grid_layout)

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton, QLineEdit
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QLabel, QHBoxLayout, QPushButton, QLineEdit, QComboBox
 
 
 class UserSettingsDialog(QDialog):
@@ -16,6 +16,7 @@ class UserSettingsDialog(QDialog):
         minimum_size_hbox = QHBoxLayout()
         maximum_width_hbox = QHBoxLayout()
         padding_hbox = QHBoxLayout()
+        font_hbox = QHBoxLayout()
 
         # Initializes the widgets of the dialog.
         encoding_table_label = QLabel("Encoding Table Settings:")
@@ -29,6 +30,12 @@ class UserSettingsDialog(QDialog):
         padding_label = QLabel("Set cell padding")
         self.padding_text_box = QLineEdit()
         self.padding_button = QPushButton("Set Padding")
+        """Creates font changing label and dropdown"""
+        font_options = ["8", "9", "10", "11", "12", "14", "16",
+                        "18", "20", "22", "24", "26", "28", "36", "48", "72"]
+        self.change_font_label = QLabel("Change font: ")
+        self.change_font_dropDown = QComboBox()
+        self.change_font_dropDown.addItems(font_options)
 
         # Adds the widgets to the internal layouts.
         minimum_size_hbox.addWidget(self.minimum_size_width_box)
@@ -38,6 +45,8 @@ class UserSettingsDialog(QDialog):
         maximum_width_hbox.addWidget(self.maximum_width_button)
         padding_hbox.addWidget(self.padding_text_box)
         padding_hbox.addWidget(self.padding_button)
+        font_hbox.addWidget(self.change_font_label)
+        font_hbox.addWidget(self.change_font_dropDown)
 
         # Adds a title for the encoding table settings to the dialog.
         dialog_layout.addWidget(encoding_table_label)
@@ -52,6 +61,8 @@ class UserSettingsDialog(QDialog):
         dialog_layout.addSpacing(50)
         dialog_layout.addWidget(padding_label)
         dialog_layout.addLayout(padding_hbox)
+        dialog_layout.addSpacing(50)
+        dialog_layout.addLayout(font_hbox)
 
         # Sets the layout of the dialog.
         self.setLayout(dialog_layout)
@@ -73,4 +84,6 @@ class UserSettingsDialog(QDialog):
         Connects a padding_button event to a slot function in the controller.
         """
         self.padding_button.clicked.connect(slot)
-    
+
+    def connect_font_to_slot(self, slot):
+        self.change_font_dropDown.activated.connect(slot)

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -86,4 +86,7 @@ class UserSettingsDialog(QDialog):
         self.padding_button.clicked.connect(slot)
 
     def connect_font_to_slot(self, slot):
+        """
+        Connects a change_font event to a slot function in the controller.
+        """
         self.change_font_dropDown.activated.connect(slot)


### PR DESCRIPTION
Adds table font size to user settings

This patch takes the table font size from the main window of the program and
moves it to user settings. It also now saves the table font size within user 
settings allowing it to persist between sessions. This was done as we felt that 
the font size should be something that persists between sessions and would 
only be accessed by the user every so often. 

Testing Steps
  1. Run the program
  2. Add "dummy" text to the encoding table
  3. Open user settings
  4. Change the font size
  5. Verify in the table that the font size was updated
  6. Close the session
  7. Re-open the session and verify font size persists
  8. Close the session and make a new session
  9. Inside the new session, add text to the table and 
      verify that it is the same font size

Type: Refactor