### PR TITLE
Sets timestamp width dependent slider margins

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -84,10 +84,8 @@ class WindowController:
         self._window.media_panel.media_control_panel.play_pause_button.clicked.connect(
             self.play_video)
 
-        self._window.media_panel.scrubber_bar.get_progress_bar().sliderMoved.connect(
+        self._window.media_panel.scalable_scrubber_bar.scrubber_bar.onValueChanged.connect(
             self.update_video_on_progres_bar_movement)
-        self._window.media_panel.scrubber_bar.scaling_bar.valueChanged.connect(
-            self.update_progress_bar_range)
 
         self._media_player.positionChanged.connect(self.update_progress_bar_on_video_position_changed)
         self._media_player.durationChanged.connect(self.on_video_duration_changed)
@@ -160,9 +158,6 @@ class WindowController:
         Opens an input dialog box to request an initial title for the encoding
         table of the session. Then, sets the initial title to the user-response.
         """
-        # text, ok = QInputDialog.getText(self._window, "Encoding Table Title Name",
-        #                                 "Encoding Table Title:", QLineEdit.Normal, "")
-        # if ok and text:
         self._window.table_panel.title.setText(table_title)
         self.resize_to_content()
 
@@ -180,7 +175,7 @@ class WindowController:
         Parameters:
             new_duration - current duration of the video.
         """
-        self._window.media_panel.scrubber_bar.initialize(new_duration)
+        self._window.media_panel.scalable_scrubber_bar.initialize(new_duration)
 
     @Slot()
     def get_video_time_total(self):
@@ -360,19 +355,8 @@ class WindowController:
         Parameters:
             position - current position of the video
         """
-        self._window.media_panel.scrubber_bar.get_progress_bar().setValue(position)
-        self._window.media_panel.scrubber_bar.scaling_progress_view.setValue(position)
-
-    # Slot annotation is not present as range_bounds is a tuple, and that is not
-    # recognized by QT. However, the slot function still connects and executes
-    # regardless.
-    def update_progress_bar_range(self, range_bounds):
-        """
-        Updates the range of the progress bar based on the new values
-        of the scalable scrubbing bar.
-        """
-        lower_range, upper_range = range_bounds
-        self._window.media_panel.scrubber_bar.set_progress_zoom(lower_range, upper_range)
+        self._window.media_panel.scalable_scrubber_bar.progress_bar.setValue(position)
+        self._window.media_panel.scalable_scrubber_bar.scrubber_bar.setValue(position)
 
     @Slot()
     def set_cell_size(self):

--- a/View/ScalableScrubbingBar/labeled_slider_tick_marks.py
+++ b/View/ScalableScrubbingBar/labeled_slider_tick_marks.py
@@ -1,0 +1,123 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsView
+
+
+def _get_timestamp(time_ms):
+    """
+    Converts the given time, in milliseconds, to a timestamp string.
+
+    Parameters:
+        time_ms - time in milliseconds to convert.
+    """
+    centi_seconds = int((time_ms / 10) % 100)
+    seconds = int((time_ms / 1000) % 60)
+    minutes = int((time_ms / (1000 * 60)) % 60)
+    hours = int((time_ms / (1000 * 60 * 60)) % 24)
+
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{centi_seconds:02d}"
+
+
+class LabeledSliderTickMarks(QGraphicsView):
+    """
+    Custom widget that draws tick marks with timestamp labels for the provided
+    slider. This widget should be placed directly below the slider.
+
+    The Labeled Slider Tick Marks class uses the QT Graphics framework to draw
+    tick marks and timestamps according to the range and zoom level of the given
+    slider.
+
+    {Note: This assumes that a certain positioning of the slider and tick mark
+     bar, mainly that the bars are vertically aligned, and that the slider has
+     a left and right content margin of 1/2 * label_width. And, the tick  mark
+     bar has no margins.}
+    """
+
+    def __init__(self, slider, label_width):
+        """
+        Constructs an instance of the labeled slider tick marks widget.
+
+        Parameters:
+            slider - the slider to draw tick marks for.
+            label_width - the width required to draw a timestamp label.
+        """
+        self._graphics_scene = QGraphicsScene()
+        super().__init__(self._graphics_scene)
+
+        self._label_width = label_width
+        self._slider = slider
+        self._slider.rangeChanged.connect(self._reposition_tick_marks)
+
+        # Configure the graphics view visual characteristics.
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        self.setFrameStyle(0)
+        self.setFixedHeight(35)
+
+        # Hard coded tick intervals, one of which is chosen for the tick marks.
+        self.tick_intervals_sec = [0.25, 0.50, 1, 1.5, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600]
+
+        # The slider handle is factored in the pixel computation of its width (estimated guess)
+        self._slider_handle_width = self._slider.minimumSizeHint().width()
+        self._slider_handle_offset = self._slider_handle_width // 2
+
+        self._label_padding = 5
+        self.setStyleSheet("background: transparent;")
+
+    def _reposition_tick_marks(self):
+        """
+        Repositions the tick marks, dynamically choosing the best tick mark interval which
+        maximizes the total number of tick marks displayed to give the user more information.
+        """
+        # Once again, this assumes the slider has a margin of 1/2 * label_width.
+        start_slider_px = self._label_width // 2 + self._slider_handle_offset
+        end_slider_px = self.width() - self._label_width // 2 - self._slider_handle_offset - 1
+
+        slider_range_ms = self._slider.maximum() - self._slider.minimum() + 1
+        slider_width_px = end_slider_px - start_slider_px
+
+        # Chooses the minimum usable tick interval. Computes the spacing required for
+        # the given interval, and determines if it can be fit without spacing overlaps.
+        chosen_interval_sec = None
+        pixels_between_ticks = None
+        for tick_interval_sec in self.tick_intervals_sec:
+            tick_interval_ms = tick_interval_sec * 1000
+            pixels_between_ticks = slider_width_px / (slider_range_ms / tick_interval_ms)
+            if pixels_between_ticks >= (self._label_width + self._label_padding):
+                chosen_interval_sec = tick_interval_sec
+                break
+
+        if chosen_interval_sec is None:
+            return
+
+        # Decide the time and starting position of the first tick-mark.
+        tick_x = start_slider_px + 1
+        curr_time_ms = self._slider.minimum()
+        if curr_time_ms % tick_interval_ms != 0:
+            curr_time_ms = ((curr_time_ms + tick_interval_ms) // tick_interval_ms) * tick_interval_ms
+            tick_x += slider_width_px / (slider_range_ms / (curr_time_ms - self._slider.minimum()))
+
+        # Draw the tick marks
+        self._graphics_scene.clear()
+        font = self.font()
+        font.setPointSize(10)
+        while tick_x < end_slider_px:
+            timestamp = _get_timestamp(curr_time_ms)
+            self._graphics_scene.addLine(tick_x, 0, tick_x, 8)
+            label = self._graphics_scene.addText(timestamp, font)
+            label.setPos(tick_x - label.boundingRect().width() / 2, 9)
+
+            tick_x += pixels_between_ticks
+            curr_time_ms += tick_interval_ms
+
+    def resizeEvent(self, e):
+        """
+        Overrides resizeEvent. This method resizes the tick mark bar to its new size,
+        and redraws its tick marks accordingly.
+
+        Parameters:
+            e - resize event
+        """
+        super().resizeEvent(e)
+        self._graphics_scene.setSceneRect(self.rect())
+        self._reposition_tick_marks()

--- a/View/ScalableScrubbingBar/scalable_scrubber_bar.py
+++ b/View/ScalableScrubbingBar/scalable_scrubber_bar.py
@@ -1,14 +1,15 @@
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QTransform, QFontMetrics
+from PySide6.QtGui import QFontMetrics
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QSlider, QHBoxLayout, QLabel
 
-from View.progress_bar_view import ProgressBarView
-from View.scaling_bar import ScalingBar
+from View.ScalableScrubbingBar.labeled_slider_tick_marks import LabeledSliderTickMarks
+from View.ScalableScrubbingBar.scaling_bar import ScalingBar
+from View.ScalableScrubbingBar.scrubber_bar import ScrubberBar
 
 
-class ScrubberBar(QWidget):
+class ScalableScrubberBar(QWidget):
     """
-    The ScrubbingBar is a custom widget, including a scaling bar and progress
+    The ScalableScrubberBar is a custom widget, including a scaling bar and progress
     bars, that when combined, form a functional scalable scrubbing bar.
     """
     DEFAULT_RANGE_BOUNDS = (0, 100)
@@ -24,6 +25,7 @@ class ScrubberBar(QWidget):
         # Since the timestamp label width will vary depending on font, we
         # compute the maximum width required to represent all timestamp labels.
         timestamp_width = self._compute_max_timestamp_width()
+        timestamp_width += 1 if timestamp_width % 2 == 1 else 0
         horizontal_margin = timestamp_width // 2
 
         # Create and configure the scaling bar.
@@ -32,53 +34,70 @@ class ScrubberBar(QWidget):
         self.scaling_bar.setBarMovesAllHandles(True)
         self.scaling_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scaling_bar.setValue((self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1]))
+        self.scaling_bar_tick_marks = LabeledSliderTickMarks(self.scaling_bar, timestamp_width)
 
         # Add a label and the scaling bar to a layout.
         scaling_bar_horizontal_layout = QHBoxLayout()
         scaling_bar_label = QLabel("Scaling Bar")
         scaling_bar_label.setFixedWidth(90)
         scaling_bar_vertical_layout = QVBoxLayout()
+        scaling_bar_vertical_layout.setSpacing(0)
         scaling_bar_vertical_layout.addWidget(self.scaling_bar_widget)
+        scaling_bar_vertical_layout.addWidget(self.scaling_bar_tick_marks)
         scaling_bar_horizontal_layout.addWidget(scaling_bar_label)
         scaling_bar_horizontal_layout.addLayout(scaling_bar_vertical_layout)
 
         # Create and configure the progress bar (read only).
-        self.scaling_progress_view = QSlider(Qt.Orientation.Horizontal)
-        self.scaling_progress_view.setEnabled(False)
+        self.progress_bar = QSlider(Qt.Orientation.Horizontal)
+        self.progress_bar.setEnabled(False)
+        self.progress_bar_tick_marks = LabeledSliderTickMarks(self.progress_bar, timestamp_width)
 
         # Add a label and the progress bar to a layout
-        scaling_progress_view_horizontal_layout = QHBoxLayout()
-        scaling_progress_view_label = QLabel("Progress Bar")
-        scaling_progress_view_label.setFixedWidth(90)
-        scaling_progress_view_layout_vertical = QVBoxLayout()
-        scaling_progress_view_layout_vertical.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
-        scaling_progress_view_layout_vertical.addWidget(self.scaling_progress_view)
-        scaling_progress_view_horizontal_layout.addWidget(scaling_progress_view_label)
-        scaling_progress_view_horizontal_layout.addLayout(scaling_progress_view_layout_vertical)
+        progress_bar_horizontal_layout = QHBoxLayout()
+        progress_bar_label = QLabel("Progress Bar")
+        progress_bar_label.setFixedWidth(90)
+        progress_bar_layout_vertical = QVBoxLayout()
+        progress_bar_layout_vertical.setSpacing(0)
+        progress_bar_inner_layout = QVBoxLayout()
+        progress_bar_inner_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        progress_bar_inner_layout.addWidget(self.progress_bar)
+        progress_bar_layout_vertical.addLayout(progress_bar_inner_layout)
+        progress_bar_layout_vertical.addWidget(self.progress_bar_tick_marks)
+        progress_bar_horizontal_layout.addWidget(progress_bar_label)
+        progress_bar_horizontal_layout.addLayout(progress_bar_layout_vertical)
 
         # Create and configure the scrubber bar
-        self.progress_bar_view = ProgressBarView()
-        progress_bar = self.get_progress_bar()
-        progress_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
-        progress_bar.setValue(self.DEFAULT_RANGE_BOUNDS[0])
+        self.scrubber_bar = ScrubberBar(self.scaling_bar)
+        self.scrubber_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
+        self.scrubber_bar.setValue(self.DEFAULT_RANGE_BOUNDS[0])
         self.slider_max = self.DEFAULT_RANGE_BOUNDS[1]
+        self.scrubber_bar_tick_marks = LabeledSliderTickMarks(self.scrubber_bar, timestamp_width)
 
         # Add a label and the scrubber bar to a layout
-        progress_bar_horizontal_layout = QHBoxLayout()
-        progress_bar_label = QLabel("Scrubber Bar")
-        progress_bar_label.setFixedWidth(90)
-        progress_bar_vertical_layout = QVBoxLayout()
-        progress_bar_vertical_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
-        progress_bar_vertical_layout.addWidget(self.progress_bar_view)
-        progress_bar_horizontal_layout.addWidget(progress_bar_label)
-        progress_bar_horizontal_layout.addLayout(progress_bar_vertical_layout)
+        scrubber_bar_horizontal_layout = QHBoxLayout()
+        scrubber_bar_label = QLabel("Scrubber Bar")
+        scrubber_bar_label.setFixedWidth(90)
+        scrubber_bar_vertical_layout = QVBoxLayout()
+        scrubber_bar_vertical_layout.setSpacing(0)
+        scrubber_bar_inner_layout = QVBoxLayout()
+        scrubber_bar_inner_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        scrubber_bar_inner_layout.addWidget(self.scrubber_bar)
+        scrubber_bar_vertical_layout.addLayout(scrubber_bar_inner_layout)
+        scrubber_bar_vertical_layout.addWidget(self.scrubber_bar_tick_marks)
+        scrubber_bar_horizontal_layout.addWidget(scrubber_bar_label)
+        scrubber_bar_horizontal_layout.addLayout(scrubber_bar_vertical_layout)
 
         # Add all three bars to this widget's vertical layout
         vertical_layout = QVBoxLayout()
         vertical_layout.addLayout(scaling_bar_horizontal_layout)
-        vertical_layout.addLayout(scaling_progress_view_horizontal_layout)
         vertical_layout.addLayout(progress_bar_horizontal_layout)
+        vertical_layout.addLayout(scrubber_bar_horizontal_layout)
         self.setLayout(vertical_layout)
+
+        # Hide the tick-mark bars until a video is loaded.
+        self.scaling_bar_tick_marks.hide()
+        self.progress_bar_tick_marks.hide()
+        self.scrubber_bar_tick_marks.hide()
 
     def initialize(self, upper_bound):
         """
@@ -94,37 +113,13 @@ class ScrubberBar(QWidget):
         self.scaling_bar.setValue((0, upper_bound))
         self.slider_max = upper_bound
 
-        self.scaling_progress_view.setRange(0, upper_bound)
+        self.progress_bar.setRange(0, upper_bound)
+        self.scrubber_bar.setRange(0, upper_bound)
 
-        progress_bar = self.get_progress_bar()
-        progress_bar.setRange(0, upper_bound)
-        progress_bar.setValue(0)
-
-        self.set_progress_zoom(0, upper_bound)
-
-    def get_progress_bar(self):
-        """
-        Getter method that returns a reference to the progress bar.
-
-        Return:
-            reference to the progress bar
-        """
-        return self.progress_bar_view.get_progress_bar()
-
-    def set_progress_zoom(self, lower_unit, upper_unit):
-        """
-        Scales and zooms the progress bar to reflect the range of the scaling
-        bar.
-
-        Parameters:
-            lower_unit - unit value (ms) of left handle of scaling bar
-            upper_unit - unit value (ms) of right handle of scaling bar
-        """
-        w, h = self.get_progress_bar().width(), self.get_progress_bar().height()
-        width_scale = (upper_unit - lower_unit) / self.slider_max
-        mid_point = (lower_unit + (upper_unit - lower_unit) / 2) / self.slider_max
-        self.progress_bar_view.setTransform(QTransform.fromScale(1 / width_scale, 1))
-        self.progress_bar_view.centerOn(mid_point * w, self.get_progress_bar().height() / 2)
+        # Display the tick-mark bars
+        self.scaling_bar_tick_marks.show()
+        self.progress_bar_tick_marks.show()
+        self.scrubber_bar_tick_marks.show()
 
     def _compute_max_timestamp_width(self):
         """
@@ -133,7 +128,9 @@ class ScrubberBar(QWidget):
         the system.
         """
         max_width = 0
-        font_metrics = QFontMetrics(self.font())
+        font = self.font()
+        font.setPointSize(10)
+        font_metrics = QFontMetrics(font)
 
         # Some digits are wider than other digits.
         for digit in range(10):

--- a/View/ScalableScrubbingBar/scaling_bar.py
+++ b/View/ScalableScrubbingBar/scaling_bar.py
@@ -1,6 +1,10 @@
 from PySide6.QtCore import Qt, Slot, QPoint
-from PySide6.QtWidgets import QWidget, QSizePolicy, QApplication, QLineEdit, QGridLayout
+from PySide6.QtWidgets import QWidget, QSizePolicy, QApplication, QGridLayout
 from superqt import QRangeSlider
+
+from View.ScalableScrubbingBar.timestamp_label import TimestampLabel
+
+
 
 
 class ScalingBar(QWidget):
@@ -102,7 +106,7 @@ class ScalingBar(QWidget):
             pos += QPoint(int(dx + self.label_shift_x), int(dy + self._label_shift_y))
             if last_edge is not None:
                 # prevent label overlap
-                pos.setX(int(max(pos.x(), last_edge.x() + label.width() / 2 + 20)))
+                pos.setX(int(max(pos.x(), last_edge.x() + label.width() / 2 + 28)))
             label.move(pos)
             last_edge = pos
             label.clearFocus()
@@ -132,56 +136,3 @@ class ScalingBar(QWidget):
         layout.setContentsMargins(margin_side, 25, margin_side, 0)
         QApplication.processEvents()
         self._reposition_labels()
-
-
-def convert_ms_to_timestamp(milliseconds):
-    """
-    Converts the given millisecond value to a timestamp.
-
-    Parameters:
-        milliseconds - milliseconds to convert.
-    """
-    seconds = (milliseconds // 1000) % 60
-    minutes = (milliseconds // (1000 * 60)) % 60
-    hours = milliseconds // (1000 * 60 * 60)
-    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-
-
-class TimestampLabel(QLineEdit):
-    """
-    Custom timestamp label, which presents the timestamp in a fixed
-    sized QLineEdit.
-
-    Note: A QLabel was not used as changes to its text triggered
-    layout updates.
-    """
-
-    def __init__(self, slider, parent, timestamp_width):
-        """
-        Constructs an instance of the timestamp label.
-
-        Parameters:
-            label - slider which the label acts on.
-            parent - parent of the slider.
-            timestamp_width - width of a timestamp label
-        """
-        super().__init__(parent=parent)
-        self._slider = slider
-
-        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.setStyleSheet("background: transparent; border: 0; color: black")
-
-        self.setFixedWidth(timestamp_width)
-
-        # Don't allow the user to edit the label.
-        self.setEnabled(False)
-
-    def set_value(self, value):
-        """
-        Sets the timestamp value of the label according to the given
-        microsecond value.
-        Parameters:
-            value - millisecond duration.
-        """
-        timestamp = convert_ms_to_timestamp(value)
-        self.setText(timestamp)

--- a/View/ScalableScrubbingBar/scrubber_bar.py
+++ b/View/ScalableScrubbingBar/scrubber_bar.py
@@ -1,0 +1,109 @@
+from PySide6.QtCore import Qt, QRect, Signal, Slot
+from PySide6.QtGui import QPainter, QColor
+from PySide6.QtWidgets import QSlider, QStyleOptionSlider, QStyle
+
+
+class ScrubberBar(QSlider):
+    """
+    Implementation of a scrubber bar where the range is dynamically altered
+    based on the values of the scaling bar, and the handle is hidden when
+    our privately tracked _value state is out of bounds. This variable is
+    important since the parent's value is bounded strictly by the slider's
+    range, whereas our variable is not.
+    """
+    onValueChanged = Signal(int)
+
+    def __init__(self, scaling_bar):
+        """
+        Constructs an instance of the scrubber bar. The passed in scaling bar is
+        the slider whose value dictates the range of this slider.
+
+        Parameters:
+            scaling_bar - slider which scales this.
+        """
+        super().__init__(Qt.Orientation.Horizontal)
+        self._value = 0
+        scaling_bar.valueChanged.connect(lambda val: self.setRange(val[0], val[1]))
+        self.sliderMoved.connect(self._slider_moved)
+
+    def setRange(self, minimum, maximum):
+        """
+        Override. Upon updating the range of the slider, if the current value
+        is greater than or equal to the new range, then the value is set to the
+        minimum or maximum. This override method sets the value of the slider to
+        our privately tracked value variable.
+
+        Parameters:
+            minimum - minimum value this slider represents
+            maximum - maximum value this slider represents
+        """
+        super().setRange(minimum, maximum)
+        super().setValue(self._value)
+
+    def setValue(self, value):
+        """
+        Override. The value is only set to the slider if it's within the
+        valid range, otherwise we don't set it. However, we do keep track
+        of the value in our privately stored value variable.
+
+        Parameters:
+            value - value of the slider to set
+        """
+        if self.minimum() <= value <= self.maximum():
+            super().setValue(value)
+        self._value = value
+        self.onValueChanged.emit(self._value)
+        self.update()
+
+    def paintEvent(self, e):
+        """
+        Complete override of slider painting. This method will hide the handle if our
+        privately stored value variable is outside the bounds of the current range.
+
+        Parameters:
+            e - paint event
+        """
+        painter = QPainter(self)
+        opt = QStyleOptionSlider()
+        self.initStyleOption(opt)
+
+        # Draw the default groove (bar)
+        opt.subControls = QStyle.SC_SliderGroove
+
+        # Get the style information of the groove and handle.
+        groove_rect = self.style().subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderGroove, self)
+        handle_rect = self.style().subControlRect(QStyle.CC_Slider, opt, QStyle.SC_SliderHandle, self)
+
+        # Create a rectangle to fill the progress from the start of the slider to the handle.
+        #   This is overriden because the default progress rect will not occupy the entire
+        #   bar when the handle is hidden.
+        progress_rect = QRect(groove_rect.left(),
+                              groove_rect.top() + 1,
+                              handle_rect.left() + 1,
+                              groove_rect.height() - 2)
+        if self._value > self.maximum():
+            progress_rect.setWidth(groove_rect.width())
+
+        # Draw the handle if the privately stored value variable is in view.
+        if self.minimum() <= self._value <= self.maximum():
+            opt.subControls |= QStyle.SC_SliderHandle
+            self.setEnabled(True)   # Make it interactive
+        else:
+            self.setEnabled(False)  # Even though it's not painted, it's still there. Make it immovable.
+
+        self.style().drawComplexControl(QStyle.CC_Slider, opt, painter, self)
+
+        # Finally, if there is progress to be shown, draw the progress rect.
+        if self._value >= self.minimum():
+            painter.setBrush(QColor(68, 160, 217))
+            painter.setPen(QColor(40, 99, 132))
+            painter.drawRect(progress_rect)
+
+    @Slot(tuple)
+    def _slider_moved(self, value):
+        """
+        Upon the user sliding the handle, we update our privately stored value variable
+        to the most up-to-date value.
+        """
+        self._value = value
+        self.onValueChanged.emit(self._value)

--- a/View/ScalableScrubbingBar/timestamp_label.py
+++ b/View/ScalableScrubbingBar/timestamp_label.py
@@ -1,0 +1,55 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QLineEdit
+
+
+def convert_ms_to_timestamp(milliseconds):
+    """
+    Converts the given millisecond value to a timestamp.
+
+    Parameters:
+        milliseconds - milliseconds to convert.
+    """
+    seconds = (milliseconds // 1000) % 60
+    minutes = (milliseconds // (1000 * 60)) % 60
+    hours = milliseconds // (1000 * 60 * 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+class TimestampLabel(QLineEdit):
+    """
+    Custom timestamp label, which presents the timestamp in a fixed
+    sized QLineEdit.
+
+    Note: A QLabel was not used as changes to its text triggered
+    layout updates.
+    """
+
+    def __init__(self, slider, parent, timestamp_width):
+        """
+        Constructs an instance of the timestamp label.
+
+        Parameters:
+            label - slider which the label acts on.
+            parent - parent of the slider.
+            timestamp_width - width of a timestamp label
+        """
+        super().__init__(parent=parent)
+        self._slider = slider
+
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.setStyleSheet("background: transparent; border: 0; color: black")
+
+        self.setFixedWidth(timestamp_width)
+
+        # Don't allow the user to edit the label.
+        self.setEnabled(False)
+
+    def set_value(self, value):
+        """
+        Sets the timestamp value of the label according to the given
+        microsecond value.
+        Parameters:
+            value - millisecond duration.
+        """
+        timestamp = convert_ms_to_timestamp(value)
+        self.setText(timestamp)

--- a/View/media_panel.py
+++ b/View/media_panel.py
@@ -2,7 +2,7 @@ from PySide6.QtMultimedia import QAudioOutput
 from PySide6.QtWidgets import QWidget, QVBoxLayout
 
 from View.media_control_panel import MediaControlPanel
-from View.scrubber_bar import ScrubberBar
+from View.ScalableScrubbingBar.scalable_scrubber_bar import ScalableScrubberBar
 from View.video_widget import VideoWidget
 
 
@@ -23,13 +23,13 @@ class MediaPanel(QWidget):
         self.media_control_panel = MediaControlPanel()
         
         # Create sliders for the scalable scrubbing bars.
-        self.scrubber_bar = ScrubberBar()
+        self.scalable_scrubber_bar = ScalableScrubberBar()
 
         # Add vertical layout box to add widgets
         vertical_layout = QVBoxLayout()
 
-        vertical_layout.addWidget(self.video_widget, stretch=7)
-        vertical_layout.addWidget(self.scrubber_bar)
+        vertical_layout.addWidget(self.video_widget)
+        vertical_layout.addWidget(self.scalable_scrubber_bar)
 
         vertical_layout.addWidget(self.media_control_panel)
         self.setLayout(vertical_layout)

--- a/View/scrubber_bar.py
+++ b/View/scrubber_bar.py
@@ -1,7 +1,6 @@
-from PySide6.QtCore import Qt, QPoint
-from PySide6.QtGui import QTransform
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QSlider, QStackedLayout, QGridLayout, QHBoxLayout, QLabel
-from superqt import QRangeSlider, QLabeledRangeSlider
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QTransform, QFontMetrics
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QSlider, QHBoxLayout, QLabel
 
 from View.progress_bar_view import ProgressBarView
 from View.scaling_bar import ScalingBar
@@ -22,48 +21,63 @@ class ScrubberBar(QWidget):
         """
         super().__init__()
 
-        self.scaling_bar = QLabeledRangeSlider(Qt.Orientation.Horizontal)
-        self.scaling_bar.setEdgeLabelMode(QLabeledRangeSlider.LabelPosition.NoLabel)
-        self.scaling_bar = ScalingBar()
+        # Since the timestamp label width will vary depending on font, we
+        # compute the maximum width required to represent all timestamp labels.
+        timestamp_width = self._compute_max_timestamp_width()
+        horizontal_margin = timestamp_width // 2
+
+        # Create and configure the scaling bar.
+        self.scaling_bar_widget = ScalingBar(timestamp_width)
+        self.scaling_bar = self.scaling_bar_widget.get_slider()
         self.scaling_bar.setBarMovesAllHandles(True)
         self.scaling_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scaling_bar.setValue((self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1]))
 
-        # This slider will be read-only, represents the progress for the scaling bar.
-        self.scaling_progress_view = QSlider(Qt.Orientation.Horizontal)
-        self.scaling_progress_view.setEnabled(False)
-
-        self.progress_bar_view = ProgressBarView()
-
-        progress_bar = self.get_progress_bar()
-        progress_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
-        progress_bar.setValue(self.DEFAULT_RANGE_BOUNDS[0])
-
-        self.slider_max = self.DEFAULT_RANGE_BOUNDS[1]
-
+        # Add a label and the scaling bar to a layout.
         scaling_bar_horizontal_layout = QHBoxLayout()
         scaling_bar_label = QLabel("Scaling Bar")
         scaling_bar_label.setFixedWidth(90)
+        scaling_bar_vertical_layout = QVBoxLayout()
+        scaling_bar_vertical_layout.addWidget(self.scaling_bar_widget)
         scaling_bar_horizontal_layout.addWidget(scaling_bar_label)
-        scaling_bar_horizontal_layout.addWidget(self.scaling_bar)
+        scaling_bar_horizontal_layout.addLayout(scaling_bar_vertical_layout)
 
+        # Create and configure the progress bar (read only).
+        self.scaling_progress_view = QSlider(Qt.Orientation.Horizontal)
+        self.scaling_progress_view.setEnabled(False)
+
+        # Add a label and the progress bar to a layout
         scaling_progress_view_horizontal_layout = QHBoxLayout()
         scaling_progress_view_label = QLabel("Progress Bar")
         scaling_progress_view_label.setFixedWidth(90)
+        scaling_progress_view_layout_vertical = QVBoxLayout()
+        scaling_progress_view_layout_vertical.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        scaling_progress_view_layout_vertical.addWidget(self.scaling_progress_view)
         scaling_progress_view_horizontal_layout.addWidget(scaling_progress_view_label)
-        scaling_progress_view_horizontal_layout.addWidget(self.scaling_progress_view)
+        scaling_progress_view_horizontal_layout.addLayout(scaling_progress_view_layout_vertical)
 
+        # Create and configure the scrubber bar
+        self.progress_bar_view = ProgressBarView()
+        progress_bar = self.get_progress_bar()
+        progress_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
+        progress_bar.setValue(self.DEFAULT_RANGE_BOUNDS[0])
+        self.slider_max = self.DEFAULT_RANGE_BOUNDS[1]
+
+        # Add a label and the scrubber bar to a layout
         progress_bar_horizontal_layout = QHBoxLayout()
         progress_bar_label = QLabel("Scrubber Bar")
         progress_bar_label.setFixedWidth(90)
+        progress_bar_vertical_layout = QVBoxLayout()
+        progress_bar_vertical_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        progress_bar_vertical_layout.addWidget(self.progress_bar_view)
         progress_bar_horizontal_layout.addWidget(progress_bar_label)
-        progress_bar_horizontal_layout.addWidget(self.progress_bar_view)
+        progress_bar_horizontal_layout.addLayout(progress_bar_vertical_layout)
 
+        # Add all three bars to this widget's vertical layout
         vertical_layout = QVBoxLayout()
         vertical_layout.addLayout(scaling_bar_horizontal_layout)
         vertical_layout.addLayout(scaling_progress_view_horizontal_layout)
         vertical_layout.addLayout(progress_bar_horizontal_layout)
-
         self.setLayout(vertical_layout)
 
     def initialize(self, upper_bound):
@@ -111,3 +125,19 @@ class ScrubberBar(QWidget):
         mid_point = (lower_unit + (upper_unit - lower_unit) / 2) / self.slider_max
         self.progress_bar_view.setTransform(QTransform.fromScale(1 / width_scale, 1))
         self.progress_bar_view.centerOn(mid_point * w, self.get_progress_bar().height() / 2)
+
+    def _compute_max_timestamp_width(self):
+        """
+        Computes the maximum timestamp width required to paint any arbitrary
+        timestamp. The width of a timestamp will depend on the font used by
+        the system.
+        """
+        max_width = 0
+        font_metrics = QFontMetrics(self.font())
+
+        # Some digits are wider than other digits.
+        for digit in range(10):
+            timestamp_with_digit_only = f"{digit}{digit}:{digit}{digit}:{digit}{digit}.{digit}{digit}"
+            max_width = max(max_width, font_metrics.horizontalAdvance(timestamp_with_digit_only))
+
+        return max_width


### PR DESCRIPTION
Before this patch, the sliders that make up the scalable scrubbing bar occupied as much vertical space as possible in the horizontal layouts they were placed in. In order to fit timestamp labels on the extreme ends of a slider, or in their future tick-mark bars, we need extra space on their left and right sides. This patch adds margins, based on the maximum width of a timestamp label, to the sides of each slider.

Testing Steps:
  1. Run the application
  2. Verify that the slider labels are left aligned
  3. Verify that each slider has the same left and right margins
  4. Verify that the timestamp labels in the scaling bar are not cut off
  5. Load a video
  6. Verify that the functionality of the sliders work as expected

Type: New Feature