### PR TITLE
Removes python-opencv dependency

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -3,7 +3,6 @@ import csv
 import math
 import sys
 
-import cv2
 from PySide6.QtCore import Slot, QMimeDatabase, QByteArray
 from PySide6.QtGui import QFontMetrics, QKeySequence
 from PySide6.QtMultimedia import QMediaFormat, QMediaPlayer
@@ -65,7 +64,6 @@ class WindowController:
             self._window.media_panel.video_widget)
         self._media_player.setAudioOutput(
             self._window.media_panel.audio_widget)
-        self.fps = None
 
         self._window.connect_load_video_to_slot(self.open_file_dialog)
         self._window.connect_settings_to_slot(self.open_settings_dialog)
@@ -182,9 +180,7 @@ class WindowController:
         Parameters:
             new_duration - current duration of the video.
         """
-        if not self.fps:
-            self.fps = self.DEFAULT_FRAMES_PER_SECOND
-        self._window.media_panel.scrubber_bar.initialize(new_duration, self.fps)
+        self._window.media_panel.scrubber_bar.initialize(new_duration)
 
     @Slot()
     def get_video_time_total(self):
@@ -284,9 +280,6 @@ class WindowController:
             url = file_dialog.selectedUrls()[0]
             self._media_player.setSource(url)
             self._media_player.play()
-
-            video = cv2.VideoCapture(url.url())
-            self.fps = video.get(cv2.CAP_PROP_FPS)
 
     @Slot()
     def save_to_file(self):

--- a/README.md
+++ b/README.md
@@ -25,16 +25,12 @@ Unix/macOS: `python3 -m pip install PySide6`
 Windows: `py -m pip install PySide6`  
 
 6. Install superqt to your virtual environment using the pip package manager.  
-Unix/macOS: `python3 -m pip install superqt`    
+Unix/macOS: `python3 -m pip install superqt`  
 Windows: `py -m pip install superqt`  
 
-7. Install opencv to your virtual environment using the pip package manager.   
-Unix/macOS: `python3 -m pip install opencv-python`    
-Windows: `py -m pip install opencv-python`  
-
-8. Run the application  
+7. Run the application  
 Unix/macOS: `python3 main.py`  
-Windows: `py main.py`
+Windows: `py main.py`  
 
 ## Development Set up
 Any text-editor or IDE, preferably with python support, can be used to develop the project. The previous steps will manually set up the project,

--- a/View/progress_bar_view.py
+++ b/View/progress_bar_view.py
@@ -23,9 +23,6 @@ class ProgressBarView(QGraphicsView):
         self.progress_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         self.scene.addWidget(self.progress_bar)
 
-        self.progress_bar.setTickInterval(100)
-        self.progress_bar.setTickPosition(QSlider.TicksBelow)
-
         super().__init__(self.scene)
         self.progress_bar.setFixedWidth(self.width())
         self.setStyleSheet("border: 0px")

--- a/View/scrubber_bar.py
+++ b/View/scrubber_bar.py
@@ -13,7 +13,6 @@ class ScrubberBar(QWidget):
     bars, that when combined, form a functional scalable scrubbing bar.
     """
     DEFAULT_RANGE_BOUNDS = (0, 100)
-    DEFAULT_FPS = 30
 
     def __init__(self):
         """
@@ -23,23 +22,16 @@ class ScrubberBar(QWidget):
         """
         super().__init__()
 
-        # Compute the default frames per millisecond.
-        self.frames_per_millisecond = 1 / (self.DEFAULT_FPS / 1000)
-
         self.scaling_bar = QLabeledRangeSlider(Qt.Orientation.Horizontal)
         self.scaling_bar.setEdgeLabelMode(QLabeledRangeSlider.LabelPosition.NoLabel)
         self.scaling_bar = ScalingBar()
         self.scaling_bar.setBarMovesAllHandles(True)
         self.scaling_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scaling_bar.setValue((self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1]))
-        self.scaling_bar.setTickInterval(self.frames_per_millisecond)
-        self.scaling_bar.setTickPosition(QSlider.TicksBelow)
 
         # This slider will be read-only, represents the progress for the scaling bar.
         self.scaling_progress_view = QSlider(Qt.Orientation.Horizontal)
         self.scaling_progress_view.setEnabled(False)
-        self.scaling_progress_view.setTickInterval(self.frames_per_millisecond)
-        self.scaling_progress_view.setTickPosition(QSlider.TicksBelow)
 
         self.progress_bar_view = ProgressBarView()
 
@@ -74,7 +66,7 @@ class ScrubberBar(QWidget):
 
         self.setLayout(vertical_layout)
 
-    def initialize(self, upper_bound, fps):
+    def initialize(self, upper_bound):
         """
         Sets the range and values of the scrubbing bar. The scaling bar will
         always range from [0, upper_bound]. The progress bar will only
@@ -83,7 +75,6 @@ class ScrubberBar(QWidget):
 
         Parameters:
             upper_bound - upper bound to set to the scrubbing bar.
-            fps - frames per second
         """
         self.scaling_bar.setRange(0, upper_bound)
         self.scaling_bar.setValue((0, upper_bound))
@@ -94,11 +85,6 @@ class ScrubberBar(QWidget):
         progress_bar = self.get_progress_bar()
         progress_bar.setRange(0, upper_bound)
         progress_bar.setValue(0)
-
-        self.frames_per_millisecond = 1 / (fps / 1000)
-        self.scaling_bar.setTickInterval(self.frames_per_millisecond)
-        self.scaling_progress_view.setTickInterval(self.frames_per_millisecond)
-        self.get_progress_bar().setTickInterval(self.frames_per_millisecond)
 
         self.set_progress_zoom(0, upper_bound)
 
@@ -114,8 +100,7 @@ class ScrubberBar(QWidget):
     def set_progress_zoom(self, lower_unit, upper_unit):
         """
         Scales and zooms the progress bar to reflect the range of the scaling
-        bar. This method also changes the tick intervals according to the zoom
-        level.
+        bar.
 
         Parameters:
             lower_unit - unit value (ms) of left handle of scaling bar
@@ -126,8 +111,3 @@ class ScrubberBar(QWidget):
         mid_point = (lower_unit + (upper_unit - lower_unit) / 2) / self.slider_max
         self.progress_bar_view.setTransform(QTransform.fromScale(1 / width_scale, 1))
         self.progress_bar_view.centerOn(mid_point * w, self.get_progress_bar().height() / 2)
-
-        if width_scale < 0.5:
-            self.get_progress_bar().setTickInterval(self.frames_per_millisecond)
-        else:
-            self.get_progress_bar().setTickInterval(self.frames_per_millisecond * 2)


### PR DESCRIPTION
This patch removes the python-opencv dependency from the README instructions, and removes all opencv related code from the codebase. The opencv module was used to get the frames per second of the loaded video. This information is no longer necessary as the tick intervals are set independent from the frame rate. In addition, we have come across installation errors caused from the python-opencv dependency. For this reason, we are removing it from the application.

This patch not only removes the frames per second data retrieval, but it also removes all QSlider tick marks as well. The slider tick intervals were based on the video frame rate found from opencv. The QSlider tick marks will not be used in the future of this application, as they are being replaced by a custom tick mark bar.

Testing Instructions:
  1. Run the application and verify all functionality works as expected.

Type: Bug Fix