### PR TITLE
Fixes media ctrl. panel component spacing + func

### DIFF
--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -102,9 +102,6 @@ class WindowController:
         self._window.table_panel.delete_col_button.clicked.connect(self.del_current_column)
         self._window.table_panel.delete_row_button.clicked.connect(self.del_current_row)
 
-        self._window.media_panel.media_control_panel.input_start_time.editingFinished.connect(self.change_scrub_start)
-        self._window.media_panel.media_control_panel.input_end_time.editingFinished.connect(self.change_scrub_end)
-
         self._window.connect_export_file_to_slot(self.save_to_file)
 
         self._window.coding_assistance_panel.button_panel.connect_add_button_to_slot(self.open_add_coding_assistance_button_dialog)
@@ -225,7 +222,7 @@ class WindowController:
 
         # Formats the time displaying current time/ total time
         # and then sets the text label in the media control panel.
-        time_str_formatted = f"Time: {current_hours:02d}:{current_minutes:02d}:{current_seconds:02d}" \
+        time_str_formatted = f"{current_hours:02d}:{current_minutes:02d}:{current_seconds:02d}" \
                              f"/{total_time_str}"
         self._window.media_panel.media_control_panel.time_stamp.setText(time_str_formatted)
 
@@ -280,6 +277,7 @@ class WindowController:
             url = file_dialog.selectedUrls()[0]
             self._media_player.setSource(url)
             self._media_player.play()
+            self.toggle_play_pause_icon()
 
     @Slot()
     def save_to_file(self):
@@ -457,24 +455,6 @@ class WindowController:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPause))
         else:
             button.setIcon(button.style().standardIcon(QStyle.SP_MediaPlay))
-
-    @Slot()
-    def change_scrub_start(self):
-        """
-        Changes the start position of the scrubbing bar.
-        """
-        str_start_time = self._window.media_panel.media_control_panel.input_start_time.text()
-        int_start_time = int(str_start_time) * 1000
-        self._window.media_panel.progress_bar.setMinimum(int_start_time)
-
-    @Slot()
-    def change_scrub_end(self):
-        """
-        Changes the end position of the scrubbing bar.
-        """
-        str_end_time = self._window.media_panel.media_control_panel.input_end_time.text()
-        int_end_time = int(str_end_time) * 1000
-        self._window.media_panel.progress_bar.setMaximum(int_end_time)
 
     @Slot()
     def open_add_coding_assistance_button_dialog(self):
@@ -748,9 +728,8 @@ class WindowController:
             return
 
         video_timestamp = self._window.media_panel.media_control_panel.time_stamp.text()
-        split_one = video_timestamp.split("Time: ")
-        split_two = split_one[1].split("/")
-        video_timestamp = split_two[0]
+        split = video_timestamp.split("/")
+        video_timestamp = split[0]
         timestamp_text = QTableWidgetItem(video_timestamp)
         for row in range(self._window.table_panel.table.rowCount()):
             column = 0

--- a/View/media_control_panel.py
+++ b/View/media_control_panel.py
@@ -1,5 +1,6 @@
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QWidget, QPushButton, QStyle, \
-    QVBoxLayout, QHBoxLayout, QLabel, QLineEdit
+    QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSizePolicy
 
 from View.playback_speed_combo_box import PlaybackSpeedComboBox
 
@@ -23,16 +24,11 @@ class MediaControlPanel(QWidget):
         # Create play pause button.
         self.play_pause_button = QPushButton()
         self.play_pause_button.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
+        self.play_pause_button.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
 
         # Create the timestamp label.
         self.time_stamp = QLabel()
-        self.time_stamp.setText("")
-
-        # Create start and end time text boxes.
-        self.input_start_time = QLineEdit()
-        self.input_start_time.setPlaceholderText("Enter Start Time")
-        self.input_end_time = QLineEdit()
-        self.input_end_time.setPlaceholderText("Enter End Time")
+        self.time_stamp.setText("00:00:00/00:00:00")
 
         # Create empty widgets to fill negative space (remove later).
         empty_widget1 = QWidget()
@@ -40,13 +36,10 @@ class MediaControlPanel(QWidget):
         empty_widget3 = QWidget()
 
         # Adds the widgets to the layout.
-        horizontal_layout.addWidget(self.playback_speed_combo_box, stretch=3)
-        horizontal_layout.addWidget(empty_widget1, stretch=3)
-        horizontal_layout.addWidget(self.play_pause_button, stretch=1)
-        horizontal_layout.addWidget(empty_widget2, stretch=4)
-        horizontal_layout.addWidget(self.time_stamp, stretch=2)
-        horizontal_layout.addWidget(empty_widget3, stretch=4)
-        horizontal_layout.addWidget(self.input_start_time, stretch=4)
-        horizontal_layout.addWidget(self.input_end_time, stretch=4)
+        horizontal_layout.addWidget(self.playback_speed_combo_box)
+        horizontal_layout.addStretch()
+        horizontal_layout.addWidget(self.play_pause_button)
+        horizontal_layout.addStretch()
+        horizontal_layout.addWidget(self.time_stamp)
 
         self.setLayout(horizontal_layout)

--- a/View/playback_speed_combo_box.py
+++ b/View/playback_speed_combo_box.py
@@ -18,6 +18,7 @@ class PlaybackSpeedComboBox(QComboBox):
 
         # Adjust the text of the 1.0 value to "Normal" and let it be the default value.
         self.setItemText(3, "Normal")
+        self.setFixedWidth(185)
         self.setCurrentIndex(3)
 
     def paintEvent(self, e):


### PR DESCRIPTION
Before this patch, when a video was loaded by the user, the video would automatically get played and the play pause button would not toggle to the pause icon. This patch adds the toggle, so that the play pause button accurately indicates the video state.

This patch also sets the spacing to the media control panel widgets in a reasonable structure. The scrubbing start / end textboxes have been removed. In addition, the timestamp label now exists before the video is loaded, so that the layout of the media control panel stays consistent. The components are aligned to the left, middle, and right extremes.

Testing Steps:
  1. Run the application
  2. Create or load a session
  3. Verify that the playback speed drop down has a width great enough to display its inner text in its entirety
  4. Verify the default 00:00:00/00:00:00 timestamp label in the right side of the media control panel
  5. Verify that the play/pause button is centered between the two aforementioned widgets
  6. Load a video
  7. Verify that the toggle of the play pause button works as expected
  8. Verify that the timestamp updates as expected

Type: Bug Fix