### PR TITLE
Close Dialogs Automatically + Edit Button Definition List in Real Time

### DIFF
--- a/Controllers/user_settings_controller.py
+++ b/Controllers/user_settings_controller.py
@@ -6,6 +6,7 @@ from View.edit_coding_assistance_button_dialog import EditCodingAssistanceButton
 from View.remove_button_definition_dialog import RemoveButtonDefinitionDialog
 from View.select_edit_button_dialog import SelectEditButtonDialog
 from View.user_settings_dialog import UserSettingsDialog
+from View.button_definition_list_element import ButtonDefinitionListElement
 
 
 class UserSettingsController:
@@ -33,13 +34,28 @@ class UserSettingsController:
         Edit a button definition in Global Settings
         """
         edit_button_id = self.select_edit_button_dialog.button_name_textbox.text()
+        button_definition_list = self.user_settings.button_definition_list.layout()
+
+        # Edit button definition in global settings
+        button_id = self.edit_button_dialog.button_id_textbox.text()
+        data = []
+        for line_edit in self.edit_button_dialog.dynamic_line_edits:
+            data.append(line_edit.text())
+
+        new_button_definition = ButtonDefinitionEntity(button_id, data)
+        new_button_definition_element = ButtonDefinitionListElement(new_button_definition)
+
+        # Edit button definition in dialog list
+        for i in range(button_definition_list.count()):
+            element = button_definition_list.itemAt(i)
+            if element and element.widget():
+                if element.widget().element_id == edit_button_id:
+                    element.widget().deleteLater()
+                    button_definition_list.addWidget(new_button_definition_element)
+
+        # Edit button definition in global settings
         for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
             if edit_button_id == button_definition.button_id:
-                button_id = self.edit_button_dialog.button_id_textbox.text()
-                data = []
-                for line_edit in self.edit_button_dialog.dynamic_line_edits:
-                    data.append(line_edit.text())
-                new_button_definition = ButtonDefinitionEntity(button_id, data)
                 self.global_settings_manager.remove_button_definition(button_definition)
                 self.global_settings_manager.add_button_definition(new_button_definition)
 
@@ -49,7 +65,9 @@ class UserSettingsController:
         Open a dialog to edit a Coding Assistance Button
         """
         self.edit_button_dialog = EditCodingAssistanceButtonDialog(self._window_controller._window.table_panel.table)
-        self.edit_button_dialog.connect_edit_button_to_slot(self.edit_coding_assistance_button)
+        self.edit_button_dialog.connect_edit_button_to_slot(
+            self.edit_coding_assistance_button,
+            self.edit_button_dialog)
         self.edit_button_dialog.exec()
 
     @Slot()
@@ -59,7 +77,8 @@ class UserSettingsController:
         """
         self.select_edit_button_dialog = SelectEditButtonDialog()
         self.select_edit_button_dialog.connect_edit_button_to_slot(
-            self.open_edit_coding_assistance_button_dialog)
+            self.open_edit_coding_assistance_button_dialog,
+            self.select_edit_button_dialog)
         self.select_edit_button_dialog.exec()
 
     @Slot()
@@ -71,6 +90,7 @@ class UserSettingsController:
         button_id = self.remove_button_definition_dialog.remove_definition_text.text()
         button_definition_list = self.user_settings.button_definition_list.layout()
 
+        # Remove button definition from list in the dialog
         for i in range(button_definition_list.count()):
             element = button_definition_list.itemAt(i)
             if element and element.widget():
@@ -89,9 +109,12 @@ class UserSettingsController:
         Open a dialog to remove a button definition from global settings
         """
         self.remove_button_definition_dialog = RemoveButtonDefinitionDialog()
-        self.remove_button_definition_dialog.connect_remove_button_to_slot(self.remove_button_definition)
+        self.remove_button_definition_dialog.connect_remove_button_to_slot(
+            self.remove_button_definition,
+            self.remove_button_definition_dialog)
         self.remove_button_definition_dialog.connect_clear_button_to_slot(
-            self.open_confirm_clear_all_button_definitions_dialog)
+            self.open_confirm_clear_all_button_definitions_dialog,
+            self.remove_button_definition_dialog)
         self.remove_button_definition_dialog.exec()
 
     @Slot()

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -467,9 +467,11 @@ class WindowController:
         """
         self.add_coding_assistance_button_dialog = AddCodingAssistanceButtonDialog(self._window.table_panel.table)
         self.add_coding_assistance_button_dialog.connect_create_button_to_slot(
-            self.open_save_coding_assistance_button_dialog)
+            self.open_save_coding_assistance_button_dialog,
+            self.add_coding_assistance_button_dialog)
         self.add_coding_assistance_button_dialog.connect_load_button_to_slot(
-            self.open_load_coding_assistance_button_dialog)
+            self.open_load_coding_assistance_button_dialog,
+            self.add_coding_assistance_button_dialog)
         self.add_coding_assistance_button_dialog.exec()
 
     @Slot()
@@ -490,7 +492,8 @@ class WindowController:
         """
         self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
             self.global_settings_manager.global_settings_entity.button_definitions)
-        self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
+        self.load_coding_assistance_button_dialog.connect_load_button_to_slot(
+            ProjectManagementController.make_lambda(
             self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons),
             self.load_coding_assistance_button_dialog)
         self.load_coding_assistance_button_dialog.exec()

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -478,7 +478,9 @@ class WindowController:
         Open a dialog to create a new Coding Assistance Button
         """
         self.delete_coding_assistance_button_dialog = DeleteCodingAssistanceButtonDialog()
-        self.delete_coding_assistance_button_dialog.connect_delete_button_to_slot(self.delete_coding_assistance_button)
+        self.delete_coding_assistance_button_dialog.connect_delete_button_to_slot(
+            self.delete_coding_assistance_button,
+            self.delete_coding_assistance_button_dialog)
         self.delete_coding_assistance_button_dialog.exec()
 
     @Slot()
@@ -489,7 +491,8 @@ class WindowController:
         self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
             self.global_settings_manager.global_settings_entity.button_definitions)
         self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
-            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons))
+            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons),
+            self.load_coding_assistance_button_dialog)
         self.load_coding_assistance_button_dialog.exec()
 
     @Slot()

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Windows: `py main.py`
 ## Development Set up
 Any text-editor or IDE, preferably with python support, can be used to develop the project. The previous steps will manually set up the project,
 however most IDEs should have support for facilitating the process described above. We recommend the PyCharm IDE for development.
+
+## User Tips
+1. When saving a button definition, the name must be globally unique.

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -65,15 +65,17 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_create_button_to_slot(self, slot):
+    def connect_create_button_to_slot(self, slot, dialog):
         """
         Connect a create_button event to a slot function in the controller.
         """
         self.create_button.clicked.connect(slot)
+        self.create_button.clicked.connect(dialog.close)
 
-    def connect_load_button_to_slot(self, slot):
+    def connect_load_button_to_slot(self, slot, dialog):
         """
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+        self.load_button.clicked.connect(dialog.close)
 

--- a/View/delete_coding_assistance_button_dialog.py
+++ b/View/delete_coding_assistance_button_dialog.py
@@ -25,8 +25,9 @@ class DeleteCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_delete_button_to_slot(self, slot):
+    def connect_delete_button_to_slot(self, slot, dialog):
         """
         Connect a delete_button event to a slot function in the controller.
         """
         self.delete_button.clicked.connect(slot)
+        self.delete_button.clicked.connect(dialog.close)

--- a/View/edit_coding_assistance_button_dialog.py
+++ b/View/edit_coding_assistance_button_dialog.py
@@ -51,8 +51,9 @@ class EditCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_edit_button_to_slot(self, slot):
+    def connect_edit_button_to_slot(self, slot, dialog):
         """
         Connect an edit_button event to a slot function in the controller.
         """
         self.edit_button.clicked.connect(slot)
+        self.edit_button.clicked.connect(dialog.close)

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -32,8 +32,9 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         dialog_layout.addWidget(self.load_button)
         self.setLayout(dialog_layout)
 
-    def connect_load_button_to_slot(self, slot):
+    def connect_load_button_to_slot(self, slot, dialog):
         """
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+        self.load_button.clicked.connect(dialog.close)

--- a/View/remove_button_definition_dialog.py
+++ b/View/remove_button_definition_dialog.py
@@ -28,14 +28,16 @@ class RemoveButtonDefinitionDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_remove_button_to_slot(self, slot):
+    def connect_remove_button_to_slot(self, slot, dialog):
         """
         Connect a remove button event to slot
         """
         self.remove_definition_button.clicked.connect(slot)
+        self.remove_definition_button.clicked.connect(dialog.close)
 
-    def connect_clear_button_to_slot(self, slot):
+    def connect_clear_button_to_slot(self, slot, dialog):
         """
         Connect a clear all button event to slot
         """
         self.clear_all_button.clicked.connect(slot)
+        self.clear_all_button.clicked.connect(dialog.close)

--- a/View/select_edit_button_dialog.py
+++ b/View/select_edit_button_dialog.py
@@ -27,8 +27,9 @@ class SelectEditButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_edit_button_to_slot(self, slot):
+    def connect_edit_button_to_slot(self, slot, dialog):
         """
         Connect a edit_button event to a slot function in the controller.
         """
         self.edit_button.clicked.connect(slot)
+        self.edit_button.clicked.connect(dialog.close)

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -93,7 +93,6 @@ class UserSettingsDialog(QDialog):
             button_definition_list_element = ButtonDefinitionListElement(button_definition)
             button_definition_layout.addWidget(button_definition_list_element)
             button_definition_layout.addSpacing(10)
-        # button_definition_layout.addSpacing(20)
         button_definition_layout.addStretch()
 
         container_widget.setLayout(button_definition_layout)


### PR DESCRIPTION
This patch allows five dialogs to close automatically when the user inputs their selections. These dialogs being the add button dialog, the delete button dialog, the remove button dialog, the edit button dialog, and the create button dialog. Additionally, this patch allows the button definition list within the user settings dialog to automatically update as soon as a button definition is edited. Finally, this patch adds to the README by telling the user that when creating button definitions, button definition names must be globally unique.

Testing Steps:
  1. Create a new session
  2. Click "+" in the "Coding Assistance Buttons" panel
  3. Create a new button and click "Yes" when prompted to save the button definition
  4. Click "Load Button"
  5. Click "Load Button" and ensure the dialog closes automatically
  6. Close the dialog
  7. Click "-" in the "Coding Assistance Buttons" panel
  8. Click "Delete" and ensure the dialog closes automatically
  9. Click "Settings" in the tool bar and click "Settings"
  10. Click "Edit Definition"
  11. Enter the name of the button created in step 2 and click "Edit"
  12. Give the button a new name and click "Edit"
  13. Ensure both dialogs have closed automatically
  14. Ensure the button definition edited has populated in the list automatically
  15. Click "Remove Definition"
  16. Enter the name of the edited button definition and click "Remove Button Definition"
  17. Ensure the dialog closes automatically
  18. Click "Remove Definition"
  19. Click "Clear all Button Definitions" and click "Yes" when prompted
  20. Ensure the dialogs close automatically
  21. Repeat steps 18-20 and click "No" when prompted

Type: New Feature