### PR TITLE
Adds labeled scalable tick marks to sliders

### DIFF
--- a/View/ScalableScrubbingBar/labeled_slider_tick_marks.py
+++ b/View/ScalableScrubbingBar/labeled_slider_tick_marks.py
@@ -1,0 +1,123 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsView
+
+
+def _get_timestamp(time_ms):
+    """
+    Converts the given time, in milliseconds, to a timestamp string.
+
+    Parameters:
+        time_ms - time in milliseconds to convert.
+    """
+    centi_seconds = int((time_ms / 10) % 100)
+    seconds = int((time_ms / 1000) % 60)
+    minutes = int((time_ms / (1000 * 60)) % 60)
+    hours = int((time_ms / (1000 * 60 * 60)) % 24)
+
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{centi_seconds:02d}"
+
+
+class LabeledSliderTickMarks(QGraphicsView):
+    """
+    Custom widget that draws tick marks with timestamp labels for the provided
+    slider. This widget should be placed directly below the slider.
+
+    The Labeled Slider Tick Marks class uses the QT Graphics framework to draw
+    tick marks and timestamps according to the range and zoom level of the given
+    slider.
+
+    {Note: This assumes that a certain positioning of the slider and tick mark
+     bar, mainly that the bars are vertically aligned, and that the slider has
+     a left and right content margin of 1/2 * label_width. And, the tick  mark
+     bar has no margins.}
+    """
+
+    def __init__(self, slider, label_width):
+        """
+        Constructs an instance of the labeled slider tick marks widget.
+
+        Parameters:
+            slider - the slider to draw tick marks for.
+            label_width - the width required to draw a timestamp label.
+        """
+        self._graphics_scene = QGraphicsScene()
+        super().__init__(self._graphics_scene)
+
+        self._label_width = label_width
+        self._slider = slider
+        self._slider.rangeChanged.connect(self._reposition_tick_marks)
+
+        # Configure the graphics view visual characteristics.
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.setAlignment(Qt.AlignTop | Qt.AlignLeft)
+        self.setFrameStyle(0)
+        self.setFixedHeight(35)
+
+        # Hard coded tick intervals, one of which is chosen for the tick marks.
+        self.tick_intervals_sec = [0.25, 0.50, 1, 1.5, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600]
+
+        # The slider handle is factored in the pixel computation of its width (estimated guess)
+        self._slider_handle_width = self._slider.minimumSizeHint().width()
+        self._slider_handle_offset = self._slider_handle_width // 2
+
+        self._label_padding = 5
+        self.setStyleSheet("background: transparent;")
+
+    def _reposition_tick_marks(self):
+        """
+        Repositions the tick marks, dynamically choosing the best tick mark interval which
+        maximizes the total number of tick marks displayed to give the user more information.
+        """
+        # Once again, this assumes the slider has a margin of 1/2 * label_width.
+        start_slider_px = self._label_width // 2 + self._slider_handle_offset
+        end_slider_px = self.width() - self._label_width // 2 - self._slider_handle_offset - 1
+
+        slider_range_ms = self._slider.maximum() - self._slider.minimum() + 1
+        slider_width_px = end_slider_px - start_slider_px
+
+        # Chooses the minimum usable tick interval. Computes the spacing required for
+        # the given interval, and determines if it can be fit without spacing overlaps.
+        chosen_interval_sec = None
+        pixels_between_ticks = None
+        for tick_interval_sec in self.tick_intervals_sec:
+            tick_interval_ms = tick_interval_sec * 1000
+            pixels_between_ticks = slider_width_px / (slider_range_ms / tick_interval_ms)
+            if pixels_between_ticks >= (self._label_width + self._label_padding):
+                chosen_interval_sec = tick_interval_sec
+                break
+
+        if chosen_interval_sec is None:
+            return
+
+        # Decide the time and starting position of the first tick-mark.
+        tick_x = start_slider_px + 1
+        curr_time_ms = self._slider.minimum()
+        if curr_time_ms % tick_interval_ms != 0:
+            curr_time_ms = ((curr_time_ms + tick_interval_ms) // tick_interval_ms) * tick_interval_ms
+            tick_x += slider_width_px / (slider_range_ms / (curr_time_ms - self._slider.minimum()))
+
+        # Draw the tick marks
+        self._graphics_scene.clear()
+        font = self.font()
+        font.setPointSize(10)
+        while tick_x < end_slider_px:
+            timestamp = _get_timestamp(curr_time_ms)
+            self._graphics_scene.addLine(tick_x, 0, tick_x, 8)
+            label = self._graphics_scene.addText(timestamp, font)
+            label.setPos(tick_x - label.boundingRect().width() / 2, 9)
+
+            tick_x += pixels_between_ticks
+            curr_time_ms += tick_interval_ms
+
+    def resizeEvent(self, e):
+        """
+        Overrides resizeEvent. This method resizes the tick mark bar to its new size,
+        and redraws its tick marks accordingly.
+
+        Parameters:
+            e - resize event
+        """
+        super().resizeEvent(e)
+        self._graphics_scene.setSceneRect(self.rect())
+        self._reposition_tick_marks()

--- a/View/ScalableScrubbingBar/scalable_scrubber_bar.py
+++ b/View/ScalableScrubbingBar/scalable_scrubber_bar.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QFontMetrics
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QSlider, QHBoxLayout, QLabel
 
+from View.ScalableScrubbingBar.labeled_slider_tick_marks import LabeledSliderTickMarks
 from View.ScalableScrubbingBar.scaling_bar import ScalingBar
 from View.ScalableScrubbingBar.scrubber_bar import ScrubberBar
 
@@ -24,6 +25,7 @@ class ScalableScrubberBar(QWidget):
         # Since the timestamp label width will vary depending on font, we
         # compute the maximum width required to represent all timestamp labels.
         timestamp_width = self._compute_max_timestamp_width()
+        timestamp_width += 1 if timestamp_width % 2 == 1 else 0
         horizontal_margin = timestamp_width // 2
 
         # Create and configure the scaling bar.
@@ -32,52 +34,70 @@ class ScalableScrubberBar(QWidget):
         self.scaling_bar.setBarMovesAllHandles(True)
         self.scaling_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scaling_bar.setValue((self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1]))
+        self.scaling_bar_tick_marks = LabeledSliderTickMarks(self.scaling_bar, timestamp_width)
 
         # Add a label and the scaling bar to a layout.
         scaling_bar_horizontal_layout = QHBoxLayout()
         scaling_bar_label = QLabel("Scaling Bar")
         scaling_bar_label.setFixedWidth(90)
         scaling_bar_vertical_layout = QVBoxLayout()
+        scaling_bar_vertical_layout.setSpacing(0)
         scaling_bar_vertical_layout.addWidget(self.scaling_bar_widget)
+        scaling_bar_vertical_layout.addWidget(self.scaling_bar_tick_marks)
         scaling_bar_horizontal_layout.addWidget(scaling_bar_label)
         scaling_bar_horizontal_layout.addLayout(scaling_bar_vertical_layout)
 
         # Create and configure the progress bar (read only).
         self.progress_bar = QSlider(Qt.Orientation.Horizontal)
         self.progress_bar.setEnabled(False)
+        self.progress_bar_tick_marks = LabeledSliderTickMarks(self.progress_bar, timestamp_width)
 
         # Add a label and the progress bar to a layout
-        progress_view_horizontal_layout = QHBoxLayout()
-        progress_view_label = QLabel("Progress Bar")
-        progress_view_label.setFixedWidth(90)
-        progress_view_layout_vertical = QVBoxLayout()
-        progress_view_layout_vertical.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
-        progress_view_layout_vertical.addWidget(self.progress_bar)
-        progress_view_horizontal_layout.addWidget(progress_view_label)
-        progress_view_horizontal_layout.addLayout(progress_view_layout_vertical)
+        progress_bar_horizontal_layout = QHBoxLayout()
+        progress_bar_label = QLabel("Progress Bar")
+        progress_bar_label.setFixedWidth(90)
+        progress_bar_layout_vertical = QVBoxLayout()
+        progress_bar_layout_vertical.setSpacing(0)
+        progress_bar_inner_layout = QVBoxLayout()
+        progress_bar_inner_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        progress_bar_inner_layout.addWidget(self.progress_bar)
+        progress_bar_layout_vertical.addLayout(progress_bar_inner_layout)
+        progress_bar_layout_vertical.addWidget(self.progress_bar_tick_marks)
+        progress_bar_horizontal_layout.addWidget(progress_bar_label)
+        progress_bar_horizontal_layout.addLayout(progress_bar_layout_vertical)
 
         # Create and configure the scrubber bar
         self.scrubber_bar = ScrubberBar(self.scaling_bar)
         self.scrubber_bar.setRange(self.DEFAULT_RANGE_BOUNDS[0], self.DEFAULT_RANGE_BOUNDS[1])
         self.scrubber_bar.setValue(self.DEFAULT_RANGE_BOUNDS[0])
         self.slider_max = self.DEFAULT_RANGE_BOUNDS[1]
+        self.scrubber_bar_tick_marks = LabeledSliderTickMarks(self.scrubber_bar, timestamp_width)
 
         # Add a label and the scrubber bar to a layout
         scrubber_bar_horizontal_layout = QHBoxLayout()
         scrubber_bar_label = QLabel("Scrubber Bar")
         scrubber_bar_label.setFixedWidth(90)
         scrubber_bar_vertical_layout = QVBoxLayout()
-        scrubber_bar_vertical_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
-        scrubber_bar_vertical_layout.addWidget(self.scrubber_bar)
+        scrubber_bar_vertical_layout.setSpacing(0)
+        scrubber_bar_inner_layout = QVBoxLayout()
+        scrubber_bar_inner_layout.setContentsMargins(horizontal_margin, 0, horizontal_margin, 0)
+        scrubber_bar_inner_layout.addWidget(self.scrubber_bar)
+        scrubber_bar_vertical_layout.addLayout(scrubber_bar_inner_layout)
+        scrubber_bar_vertical_layout.addWidget(self.scrubber_bar_tick_marks)
         scrubber_bar_horizontal_layout.addWidget(scrubber_bar_label)
         scrubber_bar_horizontal_layout.addLayout(scrubber_bar_vertical_layout)
 
         # Add all three bars to this widget's vertical layout
         vertical_layout = QVBoxLayout()
         vertical_layout.addLayout(scaling_bar_horizontal_layout)
-        vertical_layout.addLayout(progress_view_horizontal_layout)
+        vertical_layout.addLayout(progress_bar_horizontal_layout)
         vertical_layout.addLayout(scrubber_bar_horizontal_layout)
         self.setLayout(vertical_layout)
+
+        # Hide the tick-mark bars until a video is loaded.
+        self.scaling_bar_tick_marks.hide()
+        self.progress_bar_tick_marks.hide()
+        self.scrubber_bar_tick_marks.hide()
 
     def initialize(self, upper_bound):
         """
@@ -96,6 +116,11 @@ class ScalableScrubberBar(QWidget):
         self.progress_bar.setRange(0, upper_bound)
         self.scrubber_bar.setRange(0, upper_bound)
 
+        # Display the tick-mark bars
+        self.scaling_bar_tick_marks.show()
+        self.progress_bar_tick_marks.show()
+        self.scrubber_bar_tick_marks.show()
+
     def _compute_max_timestamp_width(self):
         """
         Computes the maximum timestamp width required to paint any arbitrary
@@ -103,7 +128,9 @@ class ScalableScrubberBar(QWidget):
         the system.
         """
         max_width = 0
-        font_metrics = QFontMetrics(self.font())
+        font = self.font()
+        font.setPointSize(10)
+        font_metrics = QFontMetrics(font)
 
         # Some digits are wider than other digits.
         for digit in range(10):

--- a/View/ScalableScrubbingBar/scaling_bar.py
+++ b/View/ScalableScrubbingBar/scaling_bar.py
@@ -106,7 +106,7 @@ class ScalingBar(QWidget):
             pos += QPoint(int(dx + self.label_shift_x), int(dy + self._label_shift_y))
             if last_edge is not None:
                 # prevent label overlap
-                pos.setX(int(max(pos.x(), last_edge.x() + label.width() / 2 + 20)))
+                pos.setX(int(max(pos.x(), last_edge.x() + label.width() / 2 + 28)))
             label.move(pos)
             last_edge = pos
             label.clearFocus()

--- a/View/media_panel.py
+++ b/View/media_panel.py
@@ -28,7 +28,7 @@ class MediaPanel(QWidget):
         # Add vertical layout box to add widgets
         vertical_layout = QVBoxLayout()
 
-        vertical_layout.addWidget(self.video_widget, stretch=7)
+        vertical_layout.addWidget(self.video_widget)
         vertical_layout.addWidget(self.scalable_scrubber_bar)
 
         vertical_layout.addWidget(self.media_control_panel)


### PR DESCRIPTION
This patch adds a custom scalable tick-mark bar to each slider in the scalable scrubbing bar. The tick-mark bars make assumptions about the slider width, margins, and positioning. In the future, it would be reasonable to package the slider and tick mark bars into one container class, in order to get rid of the required assumptions.

Testing Steps:
  1. Run the application
  2. Verify that there are no visible tick-marks under the bars
  3. Load a video
  4. Verify that the tick-mark bars are now present
  5. Verify the tick-mark bars of the scaling and progress bars. 5a. The ticks should start at timestamp 0, and go up to, but may not include, the end of the video. 5b. The ticks should be evenly spaced, and the text should not overlap. 5c. The number of ticks should be maximized. Verify that the next smaller interval could not be used.
  6. Verify that the tick marks appropriately respond to scaling 6a. As the scale increases, the tick intervals should become increasingly smaller 6b. As the scale changes, the handle, when paused, should not change in visual value 6c. The timestamps should reflect the scaled range of the scrubber bar 6d. Dragging the scale bar should change the timestamps appropriately

Type: New Feature