### PR TITLE
Adds the ability to access user settings from the welcome page

### DIFF
--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -15,6 +15,7 @@ class GlobalSettingsManager:
         """
         self.global_settings_entity = GlobalSettingsEntity()
 
+        # Check if global settings have been loaded upon initializing the global settings manager.
         settings = QSettings()
         if "global-settings" in settings.childGroups():
             self.load_global_settings()
@@ -88,7 +89,9 @@ class GlobalSettingsManager:
         settings.beginGroup("encoding-buttons")
 
         button_definitions_length = settings.beginReadArray("button-definitions")
-        self.global_settings_entity.button_definitions.clear()
+
+        self.global_settings_entity.button_definitions.clear()  # Clear button definitions
+
         for index in range(button_definitions_length):
             settings.setArrayIndex(index)
             button_id = settings.value("button-id")

--- a/Application/global_settings_manager.py
+++ b/Application/global_settings_manager.py
@@ -15,6 +15,10 @@ class GlobalSettingsManager:
         """
         self.global_settings_entity = GlobalSettingsEntity()
 
+        settings = QSettings()
+        if "global-settings" in settings.childGroups():
+            self.load_global_settings()
+
     def add_button_definition(self, button_definition):
         """
         Add a button definition to the button definition list
@@ -84,6 +88,7 @@ class GlobalSettingsManager:
         settings.beginGroup("encoding-buttons")
 
         button_definitions_length = settings.beginReadArray("button-definitions")
+        self.global_settings_entity.button_definitions.clear()
         for index in range(button_definitions_length):
             settings.setArrayIndex(index)
             button_id = settings.value("button-id")

--- a/Controllers/project_management_controller.py
+++ b/Controllers/project_management_controller.py
@@ -26,6 +26,8 @@ class ProjectManagementController:
         self.session_creator_page.dialog_buttons.button(QDialogButtonBox.Cancel).clicked.connect(self.back_to_mgmt_page)
         self.session_creator_page.dialog_buttons.button(QDialogButtonBox.Ok).clicked.connect(self.create_session)
 
+        self.session_manager_page.user_settings_button.clicked.connect(self._open_settings_dialog)
+
         # Iterate through all SessionOptions in the session list in the
         #   Session Manager Page and connect their signals
         session_list_layout = self.session_manager_page.session_list.layout()
@@ -131,3 +133,10 @@ class ProjectManagementController:
         session creation page.
         """
         self.project_management_window.set_current_widget(1)
+
+    @Slot()
+    def _open_settings_dialog(self):
+        """
+        Opens the settings dialog.
+        """
+        self.state_controller.user_settings_controller.open_settings_dialog()

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import Slot, QSettings
 
 from Controllers.project_management_controller import ProjectManagementController
+from Controllers.user_settings_controller import UserSettingsController
 from Controllers.window_controller import WindowController
 
 from View.main_window import MainWindow
@@ -28,6 +29,7 @@ class StateController:
         self.window_controller = None
         self.session_manager = SessionManager()
         self.global_settings_manager = GlobalSettingsManager()
+        self.user_settings_controller = UserSettingsController(self.global_settings_manager)
 
     def create_new_window(self, session_name, table_name="Default Title", video=None):
         """
@@ -43,7 +45,7 @@ class StateController:
             self.window.close()
 
         self.window = MainWindow()
-        self.window_controller = WindowController(self.window, self.global_settings_manager)
+        self.window_controller = WindowController(self.window, self.global_settings_manager, self.user_settings_controller)
         self.window.show()
 
         settings = QSettings()
@@ -115,6 +117,7 @@ class StateController:
         self.project_management_window = ProjectManagementWindow()
         self.project_management_controller = ProjectManagementController(self.project_management_window, self)
         self.project_management_window.get_widget(0).hide_session_creation_elements()
+        self.project_management_window.get_widget(0).hide_user_setting_element()
         self.project_management_window.show()
 
     @Slot()

--- a/Controllers/state_controller.py
+++ b/Controllers/state_controller.py
@@ -45,7 +45,8 @@ class StateController:
             self.window.close()
 
         self.window = MainWindow()
-        self.window_controller = WindowController(self.window, self.global_settings_manager, self.user_settings_controller)
+        self.window_controller = WindowController(self.window, self.global_settings_manager,
+                                                  self.user_settings_controller)
         self.window.show()
 
         settings = QSettings()

--- a/Controllers/user_settings_controller.py
+++ b/Controllers/user_settings_controller.py
@@ -6,6 +6,7 @@ from View.edit_coding_assistance_button_dialog import EditCodingAssistanceButton
 from View.remove_button_definition_dialog import RemoveButtonDefinitionDialog
 from View.select_edit_button_dialog import SelectEditButtonDialog
 from View.user_settings_dialog import UserSettingsDialog
+from View.button_definition_list_element import ButtonDefinitionListElement
 
 
 class UserSettingsController:
@@ -33,13 +34,28 @@ class UserSettingsController:
         Edit a button definition in Global Settings
         """
         edit_button_id = self.select_edit_button_dialog.button_name_textbox.text()
+        button_definition_list = self.user_settings.button_definition_list.layout()
+
+        # Edit button definition in global settings
+        button_id = self.edit_button_dialog.button_id_textbox.text()
+        data = []
+        for line_edit in self.edit_button_dialog.dynamic_line_edits:
+            data.append(line_edit.text())
+
+        new_button_definition = ButtonDefinitionEntity(button_id, data)
+        new_button_definition_element = ButtonDefinitionListElement(new_button_definition)
+
+        # Edit button definition in dialog list
+        for i in range(button_definition_list.count()):
+            element = button_definition_list.itemAt(i)
+            if element and element.widget():
+                if element.widget().element_id == edit_button_id:
+                    element.widget().deleteLater()
+                    button_definition_list.addWidget(new_button_definition_element)
+
+        # Edit button definition in global settings
         for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
             if edit_button_id == button_definition.button_id:
-                button_id = self.edit_button_dialog.button_id_textbox.text()
-                data = []
-                for line_edit in self.edit_button_dialog.dynamic_line_edits:
-                    data.append(line_edit.text())
-                new_button_definition = ButtonDefinitionEntity(button_id, data)
                 self.global_settings_manager.remove_button_definition(button_definition)
                 self.global_settings_manager.add_button_definition(new_button_definition)
 
@@ -49,7 +65,9 @@ class UserSettingsController:
         Open a dialog to edit a Coding Assistance Button
         """
         self.edit_button_dialog = EditCodingAssistanceButtonDialog(self._window_controller._window.table_panel.table)
-        self.edit_button_dialog.connect_edit_button_to_slot(self.edit_coding_assistance_button)
+        self.edit_button_dialog.connect_edit_button_to_slot(
+            self.edit_coding_assistance_button,
+            self.edit_button_dialog)
         self.edit_button_dialog.exec()
 
     @Slot()
@@ -59,7 +77,8 @@ class UserSettingsController:
         """
         self.select_edit_button_dialog = SelectEditButtonDialog()
         self.select_edit_button_dialog.connect_edit_button_to_slot(
-            self.open_edit_coding_assistance_button_dialog)
+            self.open_edit_coding_assistance_button_dialog,
+            self.select_edit_button_dialog)
         self.select_edit_button_dialog.exec()
 
     @Slot()
@@ -71,6 +90,7 @@ class UserSettingsController:
         button_id = self.remove_button_definition_dialog.remove_definition_text.text()
         button_definition_list = self.user_settings.button_definition_list.layout()
 
+        # Remove button definition from list in the dialog
         for i in range(button_definition_list.count()):
             element = button_definition_list.itemAt(i)
             if element and element.widget():
@@ -89,9 +109,12 @@ class UserSettingsController:
         Open a dialog to remove a button definition from global settings
         """
         self.remove_button_definition_dialog = RemoveButtonDefinitionDialog()
-        self.remove_button_definition_dialog.connect_remove_button_to_slot(self.remove_button_definition)
+        self.remove_button_definition_dialog.connect_remove_button_to_slot(
+            self.remove_button_definition,
+            self.remove_button_definition_dialog)
         self.remove_button_definition_dialog.connect_clear_button_to_slot(
-            self.open_confirm_clear_all_button_definitions_dialog)
+            self.open_confirm_clear_all_button_definitions_dialog,
+            self.remove_button_definition_dialog)
         self.remove_button_definition_dialog.exec()
 
     @Slot()

--- a/Controllers/user_settings_controller.py
+++ b/Controllers/user_settings_controller.py
@@ -1,0 +1,163 @@
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QMessageBox
+
+from Models.button_definition_entity import ButtonDefinitionEntity
+from View.edit_coding_assistance_button_dialog import EditCodingAssistanceButtonDialog
+from View.remove_button_definition_dialog import RemoveButtonDefinitionDialog
+from View.select_edit_button_dialog import SelectEditButtonDialog
+from View.user_settings_dialog import UserSettingsDialog
+
+
+class UserSettingsController:
+    """
+    The WindowController responds to input events from the Window. The Controller
+    handles the main logic of the application.
+    """
+    def __init__(self, global_settings_manager):
+        self.global_settings_manager = global_settings_manager
+        self.user_settings = None
+        self._window_controller = None
+
+    def get_dialog(self):
+        """
+        Gets a reference to the user settings dialog.
+
+        Returns:
+            reference to the user settings dialog.
+        """
+        return self.user_settings
+
+    @Slot()
+    def edit_coding_assistance_button(self):
+        """
+        Edit a button definition in Global Settings
+        """
+        edit_button_id = self.select_edit_button_dialog.button_name_textbox.text()
+        for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
+            if edit_button_id == button_definition.button_id:
+                button_id = self.edit_button_dialog.button_id_textbox.text()
+                data = []
+                for line_edit in self.edit_button_dialog.dynamic_line_edits:
+                    data.append(line_edit.text())
+                new_button_definition = ButtonDefinitionEntity(button_id, data)
+                self.global_settings_manager.remove_button_definition(button_definition)
+                self.global_settings_manager.add_button_definition(new_button_definition)
+
+    @Slot()
+    def open_edit_coding_assistance_button_dialog(self):
+        """
+        Open a dialog to edit a Coding Assistance Button
+        """
+        self.edit_button_dialog = EditCodingAssistanceButtonDialog(self._window_controller._window.table_panel.table)
+        self.edit_button_dialog.connect_edit_button_to_slot(self.edit_coding_assistance_button)
+        self.edit_button_dialog.exec()
+
+    @Slot()
+    def open_select_edit_button_dialog(self):
+        """
+        Open a dialog to select a Coding Assistance Button to edit
+        """
+        self.select_edit_button_dialog = SelectEditButtonDialog()
+        self.select_edit_button_dialog.connect_edit_button_to_slot(
+            self.open_edit_coding_assistance_button_dialog)
+        self.select_edit_button_dialog.exec()
+
+    @Slot()
+    def remove_button_definition(self):
+        """
+        Remove a button definition from Global Settings and the
+        button definition list inside the User Settings Dialog
+        """
+        button_id = self.remove_button_definition_dialog.remove_definition_text.text()
+        button_definition_list = self.user_settings.button_definition_list.layout()
+
+        for i in range(button_definition_list.count()):
+            element = button_definition_list.itemAt(i)
+            if element and element.widget():
+                if element.widget().element_id == button_id:
+                    element.widget().deleteLater()
+
+        # Remove button definition from global settings
+        for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
+            if button_id == button_definition.button_id:
+                self.global_settings_manager.remove_button_definition(button_definition)
+                self.global_settings_manager.save_encoding_button_definitions()
+
+    @Slot()
+    def open_remove_button_definition_dialog(self):
+        """
+        Open a dialog to remove a button definition from global settings
+        """
+        self.remove_button_definition_dialog = RemoveButtonDefinitionDialog()
+        self.remove_button_definition_dialog.connect_remove_button_to_slot(self.remove_button_definition)
+        self.remove_button_definition_dialog.connect_clear_button_to_slot(
+            self.open_confirm_clear_all_button_definitions_dialog)
+        self.remove_button_definition_dialog.exec()
+
+    @Slot()
+    def open_confirm_clear_all_button_definitions_dialog(self):
+        """
+        Open a dialog to ask the user if they want to clear all the encoding button definitions
+        (from global settings)
+        """
+        msg_box = QMessageBox()
+        msg_box.setText("Are you sure you want to clear all button definitions?")
+        msg_box.setStandardButtons(QMessageBox.No | QMessageBox.Yes)
+        ret = msg_box.exec()
+        self.clear_all_button_definitions(ret == QMessageBox.Yes)
+
+    @Slot(bool)
+    def clear_all_button_definitions(self, clear_definitions):
+        """
+        Clear all saved button definitions from global settings
+        """
+        button_definition_list = self.user_settings.button_definition_list.layout()
+
+        if clear_definitions:
+            while button_definition_list.count():
+                element = button_definition_list.takeAt(0)
+                if element and element.widget():
+                    element.widget().deleteLater()
+            self.global_settings_manager.global_settings_entity.button_definitions.clear()
+            self.global_settings_manager.save_encoding_button_definitions()
+
+    def open_settings_dialog(self, window_controller=None):
+        """
+        Creates the layout for the settings dialog in header menu and allows for settings to be changed
+
+        Parameters:
+            window_controller - reference to window controller if the window exists.
+
+        """
+        self.user_settings = UserSettingsDialog(self.global_settings_manager.global_settings_entity.button_definitions)
+        self._window_controller = window_controller
+
+        self.user_settings.connect_remove_button_to_slot(self.open_remove_button_definition_dialog)
+        if window_controller:
+            self.user_settings.connect_edit_button_to_slot(self.open_select_edit_button_dialog)
+            self.user_settings.connect_cell_size_to_slot(window_controller.set_cell_size)
+            self.user_settings.connect_maximum_size_to_slot(window_controller.set_maximum_width)
+            self.user_settings.connect_padding_to_slot(window_controller.set_padding)
+        else:
+            self.user_settings.edit_button.setEnabled(False)
+
+        self.user_settings.exec()
+
+        width_text = self.user_settings.minimum_size_width_box.text()
+        height_text = self.user_settings.minimum_size_height_box.text()
+        if width_text != "" and height_text != "":
+            table_cell_size = [int(width_text), int(height_text)]
+            self.global_settings_manager.set_table_cell_size(table_cell_size)
+
+        table_maximum_width = self.user_settings.maximum_width_text_box.text()
+        if table_maximum_width != "":
+            table_maximum_width = int(table_maximum_width)
+            self.global_settings_manager.set_table_maximum_width(table_maximum_width)
+
+        padding = self.user_settings.padding_text_box.text()
+        if padding != "":
+            padding = int(padding)
+            self.global_settings_manager.set_table_padding(padding)
+
+        # Saves the data to file.
+        self.global_settings_manager.save_user_settings()

--- a/Controllers/user_settings_controller.py
+++ b/Controllers/user_settings_controller.py
@@ -17,6 +17,7 @@ class UserSettingsController:
         self.global_settings_manager = global_settings_manager
         self.user_settings = None
         self._window_controller = None
+        self.empty_user_settings_flag = True
 
     def get_dialog(self):
         """
@@ -143,21 +144,29 @@ class UserSettingsController:
 
         self.user_settings.exec()
 
+        # Gets the table cell attributes from the text boxes in user settings.
         width_text = self.user_settings.minimum_size_width_box.text()
         height_text = self.user_settings.minimum_size_height_box.text()
         if width_text != "" and height_text != "":
             table_cell_size = [int(width_text), int(height_text)]
             self.global_settings_manager.set_table_cell_size(table_cell_size)
+        else:
+            self.empty_user_settings_flag = False
 
         table_maximum_width = self.user_settings.maximum_width_text_box.text()
         if table_maximum_width != "":
             table_maximum_width = int(table_maximum_width)
             self.global_settings_manager.set_table_maximum_width(table_maximum_width)
+        else:
+            self.empty_user_settings_flag = False
 
         padding = self.user_settings.padding_text_box.text()
         if padding != "":
             padding = int(padding)
             self.global_settings_manager.set_table_padding(padding)
+        else:
+            self.empty_user_settings_flag = False
 
         # Saves the data to file.
-        self.global_settings_manager.save_user_settings()
+        if self.empty_user_settings_flag is True:
+            self.global_settings_manager.save_user_settings()

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -47,16 +47,19 @@ class WindowController:
     """
     DEFAULT_FRAMES_PER_SECOND = 30
 
-    def __init__(self, window, global_settings_manager):
+    def __init__(self, window, global_settings_manager, user_settings_controller):
         """
         Constructor - Initializes the Controller instance.
 
         Parameters:
             window (MainWindow): the main Window of the application
+            global_settings_manager - reference to the global settings manager.
+            user_settings_controller - reference to the user settings controller
         """
         self._window = window
 
         self.global_settings_manager = global_settings_manager
+        self.user_settings_controller = user_settings_controller
         self.button_manager = ButtonManager()
 
         self._media_player = QMediaPlayer()
@@ -282,6 +285,13 @@ class WindowController:
             self._media_player.play()
 
     @Slot()
+    def open_settings_dialog(self):
+        """
+        Creates the layout for the settings dialog in header menu and allows for settings to be changed
+        """
+        self.user_settings_controller.open_settings_dialog(self)
+
+    @Slot()
     def save_to_file(self):
         """
         save_to_file() - Slot function that will act as a handler whenever the
@@ -314,32 +324,6 @@ class WindowController:
             file_dialog.saveFileContent(table_data_as_byte_array, "your_table_data.csv")
         else:
             file_dialog.saveFileContent(table_data_as_byte_array, title_name + ".csv")
-
-    @Slot()
-    def open_settings_dialog(self):
-        """
-        Creates the layout for the settings dialog in header menu and allows for settings to be changed
-        """
-        self.user_settings = UserSettingsDialog(self.global_settings_manager.global_settings_entity.button_definitions)
-        self.user_settings.connect_edit_button_to_slot(self.open_select_edit_button_dialog)
-        self.user_settings.connect_remove_button_to_slot(self.open_remove_button_definition_dialog)
-        self.user_settings.connect_cell_size_to_slot(self.set_cell_size)
-        self.user_settings.connect_maximum_size_to_slot(self.set_maximum_width)
-        self.user_settings.connect_padding_to_slot(self.set_padding)
-        self.user_settings.exec()
-
-        # Gets each value from the table and passes to global_settings_manager.
-        table_cell_size = self._window.table_panel.table.get_cell_size()
-        self.global_settings_manager.set_table_cell_size(table_cell_size)
-
-        table_maximum_width = self._window.table_panel.table.get_maximum_width()
-        self.global_settings_manager.set_table_maximum_width(table_maximum_width)
-
-        table_padding = self._window.table_panel.table.get_padding()
-        self.global_settings_manager.set_table_padding(table_padding)
-
-        # Saves the data to file.
-        self.global_settings_manager.save_user_settings()
 
     @Slot()
     def play_video(self):
@@ -397,8 +381,8 @@ class WindowController:
         """
         Takes input from the settings dialog and calls the set_cell_size function in the encoding table.
         """
-        width_text = self.user_settings.minimum_size_width_box.text()
-        height_text = self.user_settings.minimum_size_height_box.text()
+        width_text = self.user_settings_controller.get_dialog().minimum_size_width_box.text()
+        height_text = self.user_settings_controller.get_dialog().minimum_size_height_box.text()
         try:
             width = int(width_text)
             height = int(height_text)
@@ -411,7 +395,7 @@ class WindowController:
         """
         Takes input from the settings dialog and calls the set_maximum_width function in the encoding table.
         """
-        width_text = self.user_settings.maximum_width_text_box.text()
+        width_text = self.user_settings_controller.get_dialog().maximum_width_text_box.text()
         try:
             width = int(width_text)
             self._window.table_panel.table.set_maximum_width(width)
@@ -423,7 +407,7 @@ class WindowController:
         """
         Takes input from the settings dialog and calls the set_padding function in encoding_table.py
         """
-        padding = self.user_settings.padding_text_box.text()
+        padding = self.user_settings_controller.get_dialog().padding_text_box.text()
         self._window.table_panel.table.set_padding(padding)
 
     @Slot()
@@ -498,25 +482,6 @@ class WindowController:
         self.delete_coding_assistance_button_dialog.exec()
 
     @Slot()
-    def open_select_edit_button_dialog(self):
-        """
-        Open a dialog to select a Coding Assistance Button to edit
-        """
-        self.select_edit_button_dialog = SelectEditButtonDialog()
-        self.select_edit_button_dialog.connect_edit_button_to_slot(
-            self.open_edit_coding_assistance_button_dialog)
-        self.select_edit_button_dialog.exec()
-
-    @Slot()
-    def open_edit_coding_assistance_button_dialog(self):
-        """
-        Open a dialog to edit a Coding Assistance Button
-        """
-        self.edit_button_dialog = EditCodingAssistanceButtonDialog(self._window.table_panel.table)
-        self.edit_button_dialog.connect_edit_button_to_slot(self.edit_coding_assistance_button)
-        self.edit_button_dialog.exec()
-
-    @Slot()
     def open_load_coding_assistance_button_dialog(self):
         """
         Open a dialog to load a Coding Assistance Button
@@ -538,29 +503,6 @@ class WindowController:
         msg_box.setStandardButtons(QMessageBox.No | QMessageBox.Yes)
         ret = msg_box.exec()
         self.create_coding_assistance_button(ret == QMessageBox.Yes)
-
-    @Slot()
-    def open_remove_button_definition_dialog(self):
-        """
-        Open a dialog to remove a button definition from global settings
-        """
-        self.remove_button_definition_dialog = RemoveButtonDefinitionDialog()
-        self.remove_button_definition_dialog.connect_remove_button_to_slot(self.remove_button_definition)
-        self.remove_button_definition_dialog.connect_clear_button_to_slot(
-            self.open_confirm_clear_all_button_definitions_dialog)
-        self.remove_button_definition_dialog.exec()
-
-    @Slot()
-    def open_confirm_clear_all_button_definitions_dialog(self):
-        """
-        Open a dialog to ask the user if they want to clear all the encoding button definitions
-        (from global settings)
-        """
-        msg_box = QMessageBox()
-        msg_box.setText("Are you sure you want to clear all button definitions?")
-        msg_box.setStandardButtons(QMessageBox.No | QMessageBox.Yes)
-        ret = msg_box.exec()
-        self.clear_all_button_definitions(ret == QMessageBox.Yes)
 
     @Slot(bool)
     def create_coding_assistance_button(self, save_button):
@@ -683,58 +625,6 @@ class WindowController:
         self._window.coding_assistance_panel.button_panel.delete_coding_assistance_button(button_id)
         self.button_manager.remove_button_definition(button_id)
         self.button_manager.remove_button_hotkey(button_id)
-
-    @Slot()
-    def remove_button_definition(self):
-        """
-        Remove a button definition from Global Settings and the
-        button definition list inside the User Settings Dialog
-        """
-        button_id = self.remove_button_definition_dialog.remove_definition_text.text()
-        button_definition_list = self.user_settings.button_definition_list.layout()
-
-        for i in range(button_definition_list.count()):
-            element = button_definition_list.itemAt(i)
-            if element and element.widget():
-                if element.widget().element_id == button_id:
-                    element.widget().deleteLater()
-
-        # Remove button definition from global settings
-        for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
-            if button_id == button_definition.button_id:
-                self.global_settings_manager.remove_button_definition(button_definition)
-                self.global_settings_manager.save_encoding_button_definitions()
-
-    @Slot(bool)
-    def clear_all_button_definitions(self, clear_definitions):
-        """
-        Clear all saved button definitions from global settings
-        """
-        button_definition_list = self.user_settings.button_definition_list.layout()
-
-        if clear_definitions:
-            while button_definition_list.count():
-                element = button_definition_list.takeAt(0)
-                if element and element.widget():
-                    element.widget().deleteLater()
-            self.global_settings_manager.global_settings_entity.button_definitions.clear()
-            self.global_settings_manager.save_encoding_button_definitions()
-
-    @Slot()
-    def edit_coding_assistance_button(self):
-        """
-        Edit a button definition in Global Settings
-        """
-        edit_button_id = self.select_edit_button_dialog.button_name_textbox.text()
-        for button_definition in self.global_settings_manager.global_settings_entity.button_definitions:
-            if edit_button_id == button_definition.button_id:
-                button_id = self.edit_button_dialog.button_id_textbox.text()
-                data = []
-                for line_edit in self.edit_button_dialog.dynamic_line_edits:
-                    data.append(line_edit.text())
-                new_button_definition = ButtonDefinitionEntity(button_id, data)
-                self.global_settings_manager.remove_button_definition(button_definition)
-                self.global_settings_manager.add_button_definition(new_button_definition)
 
     @Slot(ButtonDefinitionEntity)
     def dynamic_button_click(self, button_definition):

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -467,9 +467,11 @@ class WindowController:
         """
         self.add_coding_assistance_button_dialog = AddCodingAssistanceButtonDialog(self._window.table_panel.table)
         self.add_coding_assistance_button_dialog.connect_create_button_to_slot(
-            self.open_save_coding_assistance_button_dialog)
+            self.open_save_coding_assistance_button_dialog,
+            self.add_coding_assistance_button_dialog)
         self.add_coding_assistance_button_dialog.connect_load_button_to_slot(
-            self.open_load_coding_assistance_button_dialog)
+            self.open_load_coding_assistance_button_dialog,
+            self.add_coding_assistance_button_dialog)
         self.add_coding_assistance_button_dialog.exec()
 
     @Slot()
@@ -490,7 +492,8 @@ class WindowController:
         """
         self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
             self.global_settings_manager.global_settings_entity.button_definitions)
-        self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
+        self.load_coding_assistance_button_dialog.connect_load_button_to_slot(
+            ProjectManagementController.make_lambda(
             self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons),
             self.load_coding_assistance_button_dialog)
         self.load_coding_assistance_button_dialog.exec()

--- a/Controllers/window_controller.py
+++ b/Controllers/window_controller.py
@@ -478,7 +478,9 @@ class WindowController:
         Open a dialog to create a new Coding Assistance Button
         """
         self.delete_coding_assistance_button_dialog = DeleteCodingAssistanceButtonDialog()
-        self.delete_coding_assistance_button_dialog.connect_delete_button_to_slot(self.delete_coding_assistance_button)
+        self.delete_coding_assistance_button_dialog.connect_delete_button_to_slot(
+            self.delete_coding_assistance_button,
+            self.delete_coding_assistance_button_dialog)
         self.delete_coding_assistance_button_dialog.exec()
 
     @Slot()
@@ -489,7 +491,8 @@ class WindowController:
         self.load_coding_assistance_button_dialog = LoadCodingAssistanceButtonDialog(
             self.global_settings_manager.global_settings_entity.button_definitions)
         self.load_coding_assistance_button_dialog.connect_load_button_to_slot(ProjectManagementController.make_lambda(
-            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons))
+            self.load_coding_assistance_button, self.load_coding_assistance_button_dialog.radio_buttons),
+            self.load_coding_assistance_button_dialog)
         self.load_coding_assistance_button_dialog.exec()
 
     @Slot()

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Windows: `py main.py`
 ## Development Set up
 Any text-editor or IDE, preferably with python support, can be used to develop the project. The previous steps will manually set up the project,
 however most IDEs should have support for facilitating the process described above. We recommend the PyCharm IDE for development.
+
+## User Tips
+1. When saving a button definition, the name must be globally unique.

--- a/View/add_coding_assistance_button_dialog.py
+++ b/View/add_coding_assistance_button_dialog.py
@@ -65,15 +65,17 @@ class AddCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_create_button_to_slot(self, slot):
+    def connect_create_button_to_slot(self, slot, dialog):
         """
         Connect a create_button event to a slot function in the controller.
         """
         self.create_button.clicked.connect(slot)
+        self.create_button.clicked.connect(dialog.close)
 
-    def connect_load_button_to_slot(self, slot):
+    def connect_load_button_to_slot(self, slot, dialog):
         """
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+        self.load_button.clicked.connect(dialog.close)
 

--- a/View/delete_coding_assistance_button_dialog.py
+++ b/View/delete_coding_assistance_button_dialog.py
@@ -25,8 +25,9 @@ class DeleteCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_delete_button_to_slot(self, slot):
+    def connect_delete_button_to_slot(self, slot, dialog):
         """
         Connect a delete_button event to a slot function in the controller.
         """
         self.delete_button.clicked.connect(slot)
+        self.delete_button.clicked.connect(dialog.close)

--- a/View/edit_coding_assistance_button_dialog.py
+++ b/View/edit_coding_assistance_button_dialog.py
@@ -51,8 +51,9 @@ class EditCodingAssistanceButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_edit_button_to_slot(self, slot):
+    def connect_edit_button_to_slot(self, slot, dialog):
         """
         Connect an edit_button event to a slot function in the controller.
         """
         self.edit_button.clicked.connect(slot)
+        self.edit_button.clicked.connect(dialog.close)

--- a/View/load_coding_assistance_button_dialog.py
+++ b/View/load_coding_assistance_button_dialog.py
@@ -32,8 +32,9 @@ class LoadCodingAssistanceButtonDialog(QDialog):
         dialog_layout.addWidget(self.load_button)
         self.setLayout(dialog_layout)
 
-    def connect_load_button_to_slot(self, slot):
+    def connect_load_button_to_slot(self, slot, dialog):
         """
         Connect a load_button event to a slot function in the controller.
         """
         self.load_button.clicked.connect(slot)
+        self.load_button.clicked.connect(dialog.close)

--- a/View/remove_button_definition_dialog.py
+++ b/View/remove_button_definition_dialog.py
@@ -28,14 +28,16 @@ class RemoveButtonDefinitionDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_remove_button_to_slot(self, slot):
+    def connect_remove_button_to_slot(self, slot, dialog):
         """
         Connect a remove button event to slot
         """
         self.remove_definition_button.clicked.connect(slot)
+        self.remove_definition_button.clicked.connect(dialog.close)
 
-    def connect_clear_button_to_slot(self, slot):
+    def connect_clear_button_to_slot(self, slot, dialog):
         """
         Connect a clear all button event to slot
         """
         self.clear_all_button.clicked.connect(slot)
+        self.clear_all_button.clicked.connect(dialog.close)

--- a/View/select_edit_button_dialog.py
+++ b/View/select_edit_button_dialog.py
@@ -27,8 +27,9 @@ class SelectEditButtonDialog(QDialog):
 
         self.setLayout(dialog_layout)
 
-    def connect_edit_button_to_slot(self, slot):
+    def connect_edit_button_to_slot(self, slot, dialog):
         """
         Connect a edit_button event to a slot function in the controller.
         """
         self.edit_button.clicked.connect(slot)
+        self.edit_button.clicked.connect(dialog.close)

--- a/View/session_manager_page.py
+++ b/View/session_manager_page.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout, QWidget, QScrollArea, QPushButton, QGridLayout, \
-    QHBoxLayout, QSizePolicy
+    QHBoxLayout, QSizePolicy, QStyle, QMenuBar
 
 from View.session_option import SessionOption
 
@@ -38,10 +38,15 @@ class SessionManagerPage(QDialog):
         self.clear_sessions_button = QPushButton("Clear all sessions")
         self.clear_sessions_button.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
 
+        # Create a user settings button
+        self.user_settings_button = QPushButton("User Settings")
+        self.user_settings_button.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
+
         # Add recent title and push button to horizontal layout
         recent_title_horizontal_layout.addWidget(recent_label)
         recent_title_horizontal_layout.addStretch()
         recent_title_horizontal_layout.addWidget(self.clear_sessions_button)
+        recent_title_horizontal_layout.addWidget(self.user_settings_button)
         recent_title.setLayout(recent_title_horizontal_layout)
 
         # Scrollable viewport for list of sessions
@@ -106,4 +111,11 @@ class SessionManagerPage(QDialog):
         """
         self.create_session_button.hide()
         self.start_label.hide()
+
+    def hide_user_setting_element(self):
+        """
+        Hides the user setting button element from the window. This method
+        may be useful if we want to only want to display the session manager page.
+        """
+        self.user_settings_button.hide()
 

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -93,7 +93,8 @@ class UserSettingsDialog(QDialog):
             button_definition_list_element = ButtonDefinitionListElement(button_definition)
             button_definition_layout.addWidget(button_definition_list_element)
             button_definition_layout.addSpacing(10)
-        button_definition_layout.addSpacing(20)
+        # button_definition_layout.addSpacing(20)
+        button_definition_layout.addStretch()
 
         container_widget.setLayout(button_definition_layout)
         return container_widget

--- a/View/user_settings_dialog.py
+++ b/View/user_settings_dialog.py
@@ -93,7 +93,6 @@ class UserSettingsDialog(QDialog):
             button_definition_list_element = ButtonDefinitionListElement(button_definition)
             button_definition_layout.addWidget(button_definition_list_element)
             button_definition_layout.addSpacing(10)
-        # button_definition_layout.addSpacing(20)
         button_definition_layout.addStretch()
 
         container_widget.setLayout(button_definition_layout)


### PR DESCRIPTION
Adds the ability to access user settings from the welcome page

The changes made in this patch was the creation of a user settings controller
to allow the user to access user settings from the welcome page. Many of the 
features added were just refactors of our old code base in order to make that
code work with the implementation of the user settings controller. This patch 
was done as it made sense in the users work flow to be able to access settings
from the welcome page since they applied to every session populated in the
application.

Testing Steps
  1. Load the application
  2. Verify clicking the user settings button brings up the user settings prompt
  3. Close the application and verify no errors
  4. Reopen the application and user settings and adjust all values for the table
  5. Create a session and verify the table settings were applied
  6. Create a button called button1 in the application
  7. Create a button called button2 in the application
  8. Verify they exist in user settings by opening user settings inside the current
        session
  9. Open user settings within the session and edit the table settings, verifying
      that the table was updated
  11. Close the session
  12. Reopen and verify the exist in user setting accessed from the welcome page
  13. Delete button1 from user settings
  14. Verify the change was made in user settings accessed from inside a session
        and from the welcome page

Type: New Feature