### PR TITLE
Adds a scroll area to the main window content

### DIFF
--- a/View/main_window.py
+++ b/View/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QAction
-from PySide6.QtWidgets import QMainWindow, QStyle, QHBoxLayout, QWidget, QVBoxLayout, QMessageBox
+from PySide6.QtWidgets import QMainWindow, QStyle, QHBoxLayout, QWidget, QVBoxLayout, QMessageBox, QScrollArea
 
 from View.coding_assistance_panel import CodingAssistancePanel
 from View.media_panel import MediaPanel
@@ -135,5 +135,9 @@ class MainWindow(QMainWindow):
         vertical_container_layout.addWidget(self.table_panel)
 
         central_widget = QWidget()
-        self.setCentralWidget(central_widget)
-        self.centralWidget().setLayout(vertical_container_layout)
+        central_widget.setLayout(vertical_container_layout)
+
+        scroll_area = QScrollArea(self)
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setWidget(central_widget)
+        self.setCentralWidget(scroll_area)


### PR DESCRIPTION
This patch adds the content of the entire main window into a scroll area. This was done so that the content of the window is always accessible to the user regardless of component heights and widths.

Testing Steps:
  1. Run the application
  2. Verify the main content of the main window is in a scrollable view port.

Type: New Feature